### PR TITLE
Fixes for JAGS 5.0.0. Reduce variance of diffuse normal priors.

### DIFF
--- a/R/hurdle.R
+++ b/R/hurdle.R
@@ -600,8 +600,8 @@ hurdle <- function(data, model.eff, model.cost, model.se = se ~ 1, model.sc = sc
   if(exists("gamma.prior.c", where = prior)) {gamma.prior.c = prior$gamma.prior.c} else {gamma.prior.c = NULL }
   if(exists("gamma0.prior.e", where = prior)) {gamma0.prior.e = prior$gamma0.prior.e} else {gamma0.prior.e = NULL }
   if(exists("gamma0.prior.c", where = prior)) {gamma0.prior.c = prior$gamma0.prior.c} else {gamma0.prior.c = NULL }
-  if(exists("se.prior", where = prior)) {se.prior = prior$se.prior} else {se.prior = 0.0000001 }
-  if(exists("sc.prior", where = prior)) {sc.prior = prior$sc.prior} else {sc.prior = 0.0000001 }
+  if(exists("se.prior", where = prior)) {se.prior = prior$se.prior} else {se.prior = 0.001 }
+  if(exists("sc.prior", where = prior)) {sc.prior = prior$sc.prior} else {sc.prior = 0.001 }
   if(exists("beta_f.prior", where = prior)) {beta_f.prior = prior$beta_f.prior} else {beta_f.prior = NULL }
   if(exists("mu.a0.prior", where = prior)) {mu.a0.prior = prior$mu.a0.prior} else {mu.a0.prior = NULL }
   if(exists("s.a0.prior", where = prior)) {s.a0.prior = prior$s.a0.prior} else {s.a0.prior = NULL }

--- a/R/prior_hurdle.R
+++ b/R/prior_hurdle.R
@@ -139,24 +139,24 @@ prior_hurdle <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed, zc
            if(length(alpha0.prior) != 2) {stop("provide correct hyper prior values") }
            prior_mue <- alpha0.prior
            prior_mue_str <- paste("alpha1[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-           model_string_jags <- gsub("alpha1[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags, fixed = TRUE)
+           model_string_jags <- gsub("alpha1[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags, fixed = TRUE)
            prior_mue_str <- paste("alpha2[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-           model_string_jags <- gsub("alpha2[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags, fixed = TRUE) }
+           model_string_jags <- gsub("alpha2[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags, fixed = TRUE) }
   } else if(pe_fixed > 1){
          if(is.null(alpha0.prior) == FALSE & grepl("alpha1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("alpha2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
            if(length(alpha0.prior) != 2) {stop("provide correct hyper prior values") }
            prior_mue <- alpha0.prior
            prior_mue_str <- paste("alpha1[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-           model_string_jags <- gsub("alpha1[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags, fixed = TRUE)
+           model_string_jags <- gsub("alpha1[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags, fixed = TRUE)
            prior_mue_str <- paste("alpha2[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-           model_string_jags <- gsub("alpha2[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags, fixed = TRUE) }
+           model_string_jags <- gsub("alpha2[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags, fixed = TRUE) }
             if(is.null(alpha.prior) == FALSE & grepl("alpha1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("alpha2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
               if(length(alpha.prior) != 2) {stop("provide correct hyper prior values") }
               prior_alphae <- alpha.prior
               prior_alphae_str <- paste("alpha1[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-              model_string_jags <- gsub("alpha1[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE)
+              model_string_jags <- gsub("alpha1[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE)
               prior_alphae_str <- paste("alpha2[j, 1] ~ dnorm(", prior_alphae[1],",", prior_alphae[2])
-              model_string_jags <- gsub("alpha2[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+              model_string_jags <- gsub("alpha2[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
   }
   if(length(model_e_random) != 0 & pe_random == 1) {
           if(is.null(mu.a0.prior) == FALSE & grepl("mu_a_hat[t] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
@@ -186,31 +186,31 @@ prior_hurdle <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed, zc
              if(length(beta0.prior) != 2) {stop("provide correct hyper prior values") }
              prior_muc <- beta0.prior
              prior_muc_str <- paste("beta1[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-             model_string_jags <- gsub("beta1[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE)
+             model_string_jags <- gsub("beta1[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE)
              prior_muc_str <- paste("beta2[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-             model_string_jags <- gsub("beta2[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE) }
+             model_string_jags <- gsub("beta2[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE) }
   } else if(pc_fixed > 1) {
           if(is.null(beta.prior) == FALSE & grepl("beta1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("beta2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             if(length(beta.prior) != 2) {stop("provide correct hyper prior values") }
             prior_muc <- beta.prior
             prior_muc_str <- paste("beta1[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-            model_string_jags <- gsub("beta1[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE)
+            model_string_jags <- gsub("beta1[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE)
             prior_muc_str <- paste("beta2[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-            model_string_jags <- gsub("beta2[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("beta2[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE) }
           if(is.null(beta0.prior) == FALSE & grepl("beta1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("beta2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             if(length(beta0.prior) != 2) {stop("provide correct hyper prior values") }
             prior_muc <- beta0.prior
             prior_muc_str <- paste("beta1[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-            model_string_jags <- gsub("beta1[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE)
+            model_string_jags <- gsub("beta1[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE)
             prior_muc_str <- paste("beta2[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-            model_string_jags <- gsub("beta2[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("beta2[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE) }
              if(is.null(beta.prior) == FALSE & grepl("beta1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("beta2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                if(length(beta.prior) != 2){stop("provide correct hyper prior values") }
                prior_betac <- beta.prior
                prior_betac_str <- paste("beta1[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-               model_string_jags <- gsub("beta1[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE)
+               model_string_jags <- gsub("beta1[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE)
                prior_betac_str <- paste("beta2[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-               model_string_jags <- gsub("beta2[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("beta2[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
   }
   if(length(model_c_random) != 0 & pc_random == 1) {
           if(is.null(mu.b0.prior) == FALSE & grepl("mu_b_hat[t] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
@@ -390,15 +390,15 @@ prior_hurdle <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed, zc
         if(is.null(se) == FALSE & is.null(sc) == TRUE) {
           prior_beta_f <- beta_f.prior
           prior_beta_f_str <- paste("beta_f[1] ~ dnorm(", prior_beta_f[1], ",", prior_beta_f[2])
-          model_string_jags <- gsub("beta_f[1] ~ dnorm(0, 0.0000001", prior_beta_f_str, model_string_jags, fixed = TRUE)
+          model_string_jags <- gsub("beta_f[1] ~ dnorm(0, 0.001", prior_beta_f_str, model_string_jags, fixed = TRUE)
           prior_beta_f_str <- paste("beta_f[2] ~ dnorm(", prior_beta_f[1], ",", prior_beta_f[2])
-          model_string_jags <- gsub("beta_f[2] ~ dnorm(0, 0.0000001", prior_beta_f_str, model_string_jags, fixed = TRUE)}
+          model_string_jags <- gsub("beta_f[2] ~ dnorm(0, 0.001", prior_beta_f_str, model_string_jags, fixed = TRUE)}
         if(is.null(sc) == FALSE) {
           prior_beta_f <- beta_f.prior
           prior_beta_f_str <- paste("beta_f1[1] ~ dnorm(", prior_beta_f[1], ",", prior_beta_f[2])
-          model_string_jags <- gsub("beta_f1[1] ~ dnorm(0, 0.0000001", prior_beta_f_str, model_string_jags, fixed = TRUE)
+          model_string_jags <- gsub("beta_f1[1] ~ dnorm(0, 0.001", prior_beta_f_str, model_string_jags, fixed = TRUE)
           prior_beta_f_str <- paste("beta_f2[1] ~ dnorm(", prior_beta_f[1], ",",prior_beta_f[2])
-          model_string_jags <- gsub("beta_f2[1] ~ dnorm(0, 0.0000001", prior_beta_f_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_f2[1] ~ dnorm(0, 0.001", prior_beta_f_str, model_string_jags, fixed = TRUE) }
         }
     }
     if(exists("mu.b_f.prior") == TRUE) {

--- a/R/prior_long_miss.R
+++ b/R/prior_long_miss.R
@@ -165,22 +165,22 @@ prior_long_miss <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(alpha0.prior) != 2) {stop("provide correct hyper prior values") }
         prior_mue <- alpha0.prior
         prior_mue_str <- paste("alpha[1, time] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-        model_string_jags <- gsub("alpha[1, time] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE)
+        model_string_jags <- gsub("alpha[1, time] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE)
         prior_mue_str <- paste("alpha[2, time] ~ dnorm(", prior_mue[1],",", prior_mue[2])
-        model_string_jags <- gsub("alpha[2, time] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("alpha[2, time] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags, fixed = TRUE) }
     } else if(pe_fixed > 1){
       if(is.null(alpha0.prior) == FALSE & grepl("alpha[1, 1, time] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("alpha[1, 2, time] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
         if(length(alpha0.prior) != 2) {stop("provide correct hyper prior values") }
         prior_mue <- alpha0.prior
         prior_mue_str <- paste("alpha[1, 1, time] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-        model_string_jags <- gsub("alpha[1, 1, time] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE)
+        model_string_jags <- gsub("alpha[1, 1, time] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE)
         prior_mue_str <- paste("alpha[1, 2, time] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-        model_string_jags <- gsub("alpha[1, 2, time] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("alpha[1, 2, time] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags, fixed = TRUE) }
         if(is.null(alpha.prior) == FALSE & grepl("alpha[j, t, time] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
         if(length(alpha.prior) != 2) {stop("provide correct hyper prior values") }
         prior_alphae <- alpha.prior
         prior_alphae_str <- paste("alpha[j, t, time] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-        model_string_jags <- gsub("alpha[j, t, time] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("alpha[j, t, time] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
     }
     if(length(model_e_random) != 0 & pe_random == 1) {
       if(is.null(mu.a0.prior) == FALSE & grepl("mu_a_hat[t, time] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
@@ -210,22 +210,22 @@ prior_long_miss <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(beta0.prior) != 2) {stop("provide correct hyper prior values") }
         prior_muc <- beta0.prior
         prior_muc_str <- paste("beta[1, time] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-        model_string_jags <- gsub("beta[1, time] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE)
+        model_string_jags <- gsub("beta[1, time] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE)
         prior_muc_str <- paste("beta[2, time] ~ dnorm(",prior_muc[1],",", prior_muc[2])
-        model_string_jags <- gsub("beta[2, time] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("beta[2, time] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE) }
     } else if(pc_fixed > 1) {
       if(is.null(beta0.prior) == FALSE & grepl("beta[1, 1, time] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("beta[1, 2, time] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
         if(length(beta0.prior) != 2) {stop("provide correct hyper prior values") }
         prior_muc <- beta0.prior
         prior_muc_str <- paste("beta[1, 1, time] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-        model_string_jags <- gsub("beta[1, 1, time] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE)
+        model_string_jags <- gsub("beta[1, 1, time] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE)
         prior_muc_str <- paste("beta[1, 2, time] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-        model_string_jags <- gsub("beta[1, 2, time] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("beta[1, 2, time] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta[j, t, time] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
         if(length(beta.prior) != 2){stop("provide correct hyper prior values") }
         prior_betac <- beta.prior
         prior_betac_str <- paste("beta[j, t, time] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-        model_string_jags <- gsub("beta[j, t, time] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("beta[j, t, time] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
     }
     if(length(model_c_random) != 0 & pc_random == 1) {
       if(is.null(mu.b0.prior) == FALSE & grepl("mu_b_hat[t, time] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
@@ -308,7 +308,7 @@ prior_long_miss <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(beta_f.prior) != 2) {stop("provide correct hyper prior values") }
           prior_beta_f <- beta_f.prior
           prior_beta_f_str <- paste("beta_f[t, time] ~ dnorm(", prior_beta_f[1], ",", prior_beta_f[2])
-          model_string_jags <- gsub("beta_f[t, time] ~ dnorm(0, 0.0000001", prior_beta_f_str, model_string_jags, fixed = TRUE)
+          model_string_jags <- gsub("beta_f[t, time] ~ dnorm(0, 0.001", prior_beta_f_str, model_string_jags, fixed = TRUE)
        }
      }
     if(exists("mu.b_f.prior") == TRUE) {
@@ -332,7 +332,7 @@ prior_long_miss <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(beta_te.prior) != 2) {stop("provide correct hyper prior values") }
         prior_beta_te <- beta_te.prior
         prior_beta_te_str <- paste("beta_te[t, time] ~ dnorm(", prior_beta_te[1], ",", prior_beta_te[2])
-        model_string_jags <- gsub("beta_te[t, time] ~ dnorm(0, 0.0000001", prior_beta_te_str, model_string_jags, fixed = TRUE)
+        model_string_jags <- gsub("beta_te[t, time] ~ dnorm(0, 0.001", prior_beta_te_str, model_string_jags, fixed = TRUE)
       }
     }
     if(exists("beta_tc.prior") == TRUE) {
@@ -340,7 +340,7 @@ prior_long_miss <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(beta_tc.prior) != 2) {stop("provide correct hyper prior values") }
         prior_beta_tc <- beta_tc.prior
         prior_beta_tc_str <- paste("beta_tc[t, time] ~ dnorm(", prior_beta_tc[1], ",", prior_beta_tc[2])
-        model_string_jags <- gsub("beta_tc[t, time] ~ dnorm(0, 0.0000001", prior_beta_tc_str, model_string_jags, fixed = TRUE)
+        model_string_jags <- gsub("beta_tc[t, time] ~ dnorm(0, 0.001", prior_beta_tc_str, model_string_jags, fixed = TRUE)
       }
     }
     if(exists("mu.b_te.prior") == TRUE) {
@@ -380,7 +380,7 @@ prior_long_miss <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(alpha_te.prior) != 2) {stop("provide correct hyper prior values") }
         prior_alpha_te <- alpha_te.prior
         prior_alpha_te_str <- paste("alpha_te[t, time] ~ dnorm(", prior_alpha_te[1], ",", prior_alpha_te[2])
-        model_string_jags <- gsub("alpha_te[t, time] ~ dnorm(0, 0.0000001", prior_alpha_te_str, model_string_jags, fixed = TRUE)
+        model_string_jags <- gsub("alpha_te[t, time] ~ dnorm(0, 0.001", prior_alpha_te_str, model_string_jags, fixed = TRUE)
       }
     }
     if(exists("alpha_tc.prior") == TRUE) {
@@ -388,7 +388,7 @@ prior_long_miss <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(alpha_tc.prior) != 2) {stop("provide correct hyper prior values") }
         prior_alpha_tc <- alpha_tc.prior
         prior_alpha_tc_str <- paste("alpha_tc[t, time] ~ dnorm(", prior_alpha_tc[1], ",", prior_alpha_tc[2])
-        model_string_jags <- gsub("alpha_tc[t, time] ~ dnorm(0, 0.0000001", prior_alpha_tc_str, model_string_jags, fixed = TRUE)
+        model_string_jags <- gsub("alpha_tc[t, time] ~ dnorm(0, 0.001", prior_alpha_tc_str, model_string_jags, fixed = TRUE)
       }
     }
     if(exists("mu.a_te.prior") == TRUE) {

--- a/R/prior_pattern.R
+++ b/R/prior_pattern.R
@@ -33,100 +33,100 @@ prior_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, model_e_rand
          if(d_list$n_patterns[1] == 4) {
            if(grepl("alpha_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p1[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
            if(grepl("alpha_p1[3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p1[3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+            model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
          } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_c_obs == FALSE & restriction == "CC") {
            if(grepl("alpha_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
            if(grepl("alpha_p1[3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+             model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
          } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_ec_obs == FALSE & restriction == "AC") {
            if(grepl("alpha_p1[3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+             model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
          } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_e_obs == FALSE & restriction == "CC") {
            if(grepl("alpha_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
          } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_ec_mis == FALSE) {
            if(grepl("alpha_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
            if(grepl("alpha_p1[3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+             model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
          } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_c_obs == FALSE & d_list$d1$d1_e_obs == FALSE & restriction == "CC") {
            if(grepl("alpha_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
          } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_c_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "CC") {
            if(grepl("alpha_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
            if(grepl("alpha_p1[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[2] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[2] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+             model_string_jags <- gsub("alpha_p1[2] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
          } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_e_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "CC") {
            if(grepl("alpha_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
          } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_ec_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "AC") {
            if(grepl("alpha_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
              prior_mue_str <- paste("alpha_p1[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+             model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
          }
         if(d_list$n_patterns[2] == 4) {
           if(grepl("alpha_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(grepl("alpha_p2[3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+            model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
         } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_c_obs == FALSE & restriction == "CC") {
           if(grepl("alpha_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(grepl("alpha_p2[3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+            model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
         } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_ec_obs == FALSE & restriction == "AC") {
           if(grepl("alpha_p2[3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+            model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
         } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_e_obs == FALSE & restriction == "CC") {
           if(grepl("alpha_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_ec_mis == FALSE) {
           if(grepl("alpha_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(grepl("alpha_p2[3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+            model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
         } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_c_obs == FALSE & d_list$d2$d2_e_obs == FALSE & restriction == "CC") {
           if(grepl("alpha_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_c_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "CC") {
           if(grepl("alpha_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(grepl("alpha_p2[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[2] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[2] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[2] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_e_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "CC") {
           if(grepl("alpha_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_ec_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "AC") {
           if(grepl("alpha_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue_str <- paste("alpha_p2[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
         }
       }
     } else if(pe_fixed > 1){
@@ -141,79 +141,79 @@ prior_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, model_e_rand
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+               model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
              if(is.null(alpha.prior) == FALSE & grepl("alpha_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_alphae <- alpha.prior
                prior_alphae_str <- paste("alpha_p1[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) 
+               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) 
                prior_alphae_str <- paste("alpha_p1[j, 3] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
            } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_c_obs == FALSE & restriction == "CC") {
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha.prior) == FALSE & grepl("alpha_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_alphae <- alpha.prior
                prior_alphae_str <- paste("alpha_p1[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) 
+               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) 
                prior_alphae_str <- paste("alpha_p1[j, 3] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
            } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_ec_obs == FALSE & restriction == "AC") {
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha.prior) == FALSE & grepl("alpha_p1[j, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_alphae <- alpha.prior
                prior_alphae_str <- paste("alpha_p1[j, 3] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
            } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_e_obs == FALSE & restriction == "CC") {
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha.prior) == FALSE & grepl("alpha_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_alphae <- alpha.prior
                prior_alphae_str <- paste("alpha_p1[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
            } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_ec_mis == FALSE) {
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha.prior) == FALSE & grepl("alpha_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_alphae <- alpha.prior
                prior_alphae_str <- paste("alpha_p1[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) 
+               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) 
                prior_alphae_str <- paste("alpha_p1[j, 3] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
            } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_c_obs == FALSE & d_list$d1$d1_e_obs == FALSE & restriction == "CC") {
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha.prior) == FALSE & grepl("alpha_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_alphae <- alpha.prior
                prior_alphae_str <- paste("alpha_p1[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
            } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_c_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "CC") {
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 2] <- ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 2] ~ dnorm(", prior_mue[1], ",", prior_mue[2], ")")
@@ -221,105 +221,105 @@ prior_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, model_e_rand
              if(is.null(alpha.prior) == FALSE & grepl("alpha_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_alphae <- alpha.prior
                prior_alphae_str <- paste("alpha_p1[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) 
+               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) 
                prior_alphae_str <- paste("alpha_p1[j, 2] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 2] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[j, 2] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
            } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_e_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "CC") {
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha.prior) == FALSE & grepl("alpha_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_alphae <- alpha.prior
                prior_alphae_str <- paste("alpha_p1[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
            } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_ec_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "AC") {
              if(is.null(alpha0.prior) == FALSE & grepl("alpha_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_mue <- alpha0.prior
                prior_mue_str <- paste("alpha_p1[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
              if(is.null(alpha.prior) == FALSE & grepl("alpha_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
                prior_alphae <- alpha.prior
                prior_alphae_str <- paste("alpha_p1[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+               model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
            }
         if(d_list$n_patterns[2] == 4) {
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha.prior) == FALSE & grepl("alpha_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_alphae <- alpha.prior
             prior_alphae_str <- paste("alpha_p2[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) 
+            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) 
             prior_alphae_str <- paste("alpha_p2[j, 3] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_c_obs == FALSE & restriction == "CC") {
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+            model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
           if(is.null(alpha.prior) == FALSE & grepl("alpha_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_alphae <- alpha.prior
             prior_alphae_str <- paste("alpha_p2[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) 
+            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) 
             prior_alphae_str <- paste("alpha_p2[j, 3] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_ec_obs == FALSE & restriction == "AC") {
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) } 
+            model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) } 
           if(is.null(alpha.prior) == FALSE & grepl("alpha_p2[j, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_alphae <- alpha.prior
             prior_alphae_str <- paste("alpha_p2[j, 3] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_e_obs == FALSE & restriction == "CC") {
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha.prior) == FALSE & grepl("alpha_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_alphae <- alpha.prior
             prior_alphae_str <- paste("alpha_p2[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_ec_mis == FALSE) {
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 3] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 3] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha.prior) == FALSE & grepl("alpha_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_alphae <- alpha.prior
             prior_alphae_str <- paste("alpha_p2[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) 
+            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) 
             prior_alphae_str <- paste("alpha_p2[j, 3] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_c_obs == FALSE & d_list$d2$d2_e_obs == FALSE & restriction == "CC") {
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha.prior) == FALSE & grepl("alpha_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_alphae <- alpha.prior
             prior_alphae_str <- paste("alpha_p2[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_c_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "CC") {
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 2] <- ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 2] ~ dnorm(", prior_mue[1], ",", prior_mue[2], ")")
@@ -327,27 +327,27 @@ prior_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, model_e_rand
           if(is.null(alpha.prior) == FALSE & grepl("alpha_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_alphae <- alpha.prior
             prior_alphae_str <- paste("alpha_p2[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) 
+            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) 
             prior_alphae_str <- paste("alpha_p2[j, 2] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 2] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[j, 2] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_e_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "CC") {
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha.prior) == FALSE & grepl("alpha_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_alphae <- alpha.prior
             prior_alphae_str <- paste("alpha_p2[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
         } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_ec_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "AC") {
           if(is.null(alpha0.prior) == FALSE & grepl("alpha_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_mue <- alpha0.prior
             prior_mue_str <- paste("alpha_p2[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE) }
           if(is.null(alpha.prior) == FALSE & grepl("alpha_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_alphae <- alpha.prior
             prior_alphae_str <- paste("alpha_p2[j, 1] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+            model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
         }
       }
     }
@@ -358,100 +358,100 @@ prior_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, model_e_rand
       if(d_list$n_patterns[1] == 4) {
         if(grepl("beta_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(grepl("beta_p1[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_c_obs == FALSE & restriction == "CC") {
         if(grepl("beta_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_ec_obs == FALSE & restriction == "AC") {
         if(grepl("beta_p1[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_e_obs == FALSE & restriction == "CC") {
         if(grepl("beta_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(grepl("beta_p1[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_ec_mis == FALSE) {
         if(grepl("beta_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(grepl("beta_p1[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) } 
+          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) } 
       } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_c_obs == FALSE & d_list$d1$d1_e_obs == FALSE & restriction == "CC") {
         if(grepl("beta_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_c_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "CC") {
         if(grepl("beta_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_e_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "CC") {
         if(grepl("beta_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(grepl("beta_p1[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_ec_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "AC") {
         if(grepl("beta_p1[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p1[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       }
       if(d_list$n_patterns[2] == 4) {
         if(grepl("beta_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(grepl("beta_p2[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) } 
+          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) } 
       } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_c_obs == FALSE & restriction == "CC") {
         if(grepl("beta_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_ec_obs == FALSE & restriction == "AC") {
         if(grepl("beta_p2[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_e_obs == FALSE & restriction == "CC") {
         if(grepl("beta_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(grepl("beta_p2[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_ec_mis == FALSE) {
         if(grepl("beta_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(grepl("beta_p2[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) } 
+          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) } 
       } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_c_obs == FALSE & d_list$d2$d2_e_obs == FALSE & restriction == "CC") {
         if(grepl("beta_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_c_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "CC") {
         if(grepl("beta_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_e_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "CC") {
         if(grepl("beta_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(grepl("beta_p2[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_ec_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "AC") {
         if(grepl("beta_p2[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc_str <- paste("beta_p2[2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
       }
     }
   } else if(pc_fixed > 1){
@@ -466,213 +466,213 @@ prior_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, model_e_rand
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p1[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) 
           prior_betac_str <- paste("beta_p1[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_c_obs == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p1[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_ec_obs == FALSE & restriction == "AC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p1[j, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p1[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_e_obs == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p1[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) 
           prior_betac_str <- paste("beta_p1[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 3 & d_list$d1$d1_ec_mis == FALSE) {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p1[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) 
           prior_betac_str <- paste("beta_p1[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_c_obs == FALSE & d_list$d1$d1_e_obs == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p1[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_c_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p1[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_e_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p1[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p1[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) 
           prior_betac_str <- paste("beta_p1[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[1] == 2 & d_list$d1$d1_ec_obs == FALSE & d_list$d1$d1_ec_mis == FALSE & restriction == "AC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p1[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p1[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p1[j, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p1[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       }
       if(d_list$n_patterns[2] == 4) {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p2[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) 
           prior_betac_str <- paste("beta_p2[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_c_obs == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p2[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_ec_obs == FALSE & restriction == "AC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p2[j, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p2[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_e_obs == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p2[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) 
           prior_betac_str <- paste("beta_p2[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 3 & d_list$d2$d2_ec_mis == FALSE) {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p2[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) 
           prior_betac_str <- paste("beta_p2[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_c_obs == FALSE & d_list$d2$d2_e_obs == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p2[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_c_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p2[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_e_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "CC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p2[j, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p2[j, 1] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) 
           prior_betac_str <- paste("beta_p2[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       } else if(d_list$n_patterns[2] == 2 & d_list$d2$d2_ec_obs == FALSE & d_list$d2$d2_ec_mis == FALSE & restriction == "AC") {
         if(is.null(beta0.prior) == FALSE & grepl("beta_p2[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_muc <- beta0.prior
           prior_muc_str <- paste("beta_p2[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags,fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags,fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta_p2[j, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
           prior_betac <- beta.prior
           prior_betac_str <- paste("beta_p2[j, 2] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+          model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
       }
     }
   }
@@ -1511,10 +1511,10 @@ prior_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, model_e_rand
         prior_beta_f <- beta_f.prior 
           if(grepl("beta_f_p1[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_beta_f_str <- paste("beta_f_p1[1] ~ dnorm(", prior_beta_f[1], ",", prior_beta_f[2])
-            model_string_jags <- gsub("beta_f_p1[1] ~ dnorm(0, 0.0000001", prior_beta_f_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("beta_f_p1[1] ~ dnorm(0, 0.001", prior_beta_f_str, model_string_jags,fixed = TRUE) }
           if(grepl("beta_f_p2[1] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
             prior_beta_f_str <- paste("beta_f_p2[1] ~ dnorm(", prior_beta_f[1], ",", prior_beta_f[2])
-            model_string_jags <- gsub("beta_f_p2[1] ~ dnorm(0, 0.0000001", prior_beta_f_str, model_string_jags,fixed = TRUE) }
+            model_string_jags <- gsub("beta_f_p2[1] ~ dnorm(0, 0.001", prior_beta_f_str, model_string_jags,fixed = TRUE) }
         }
     }
     if(length(model_e_random) != 0 & pe_random == 1) {

--- a/R/prior_selection.R
+++ b/R/prior_selection.R
@@ -157,22 +157,22 @@ prior_selection <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(alpha0.prior) != 2) {stop("provide correct hyper prior values") }
         prior_mue <- alpha0.prior
         prior_mue_str <- paste("alpha[1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-        model_string_jags <- gsub("alpha[1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE)
+        model_string_jags <- gsub("alpha[1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE)
         prior_mue_str <- paste("alpha[2] ~ dnorm(", prior_mue[1],",", prior_mue[2])
-        model_string_jags <- gsub("alpha[2] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("alpha[2] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags, fixed = TRUE) }
     } else if(pe_fixed > 1){
       if(is.null(alpha0.prior) == FALSE & grepl("alpha[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("alpha[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
         if(length(alpha0.prior) != 2) {stop("provide correct hyper prior values") }
         prior_mue <- alpha0.prior
         prior_mue_str <- paste("alpha[1, 1] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-        model_string_jags <- gsub("alpha[1, 1] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags,fixed = TRUE)
+        model_string_jags <- gsub("alpha[1, 1] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags,fixed = TRUE)
         prior_mue_str <- paste("alpha[1, 2] ~ dnorm(", prior_mue[1], ",", prior_mue[2])
-        model_string_jags <- gsub("alpha[1, 2] ~ dnorm(0, 0.0000001", prior_mue_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("alpha[1, 2] ~ dnorm(0, 0.001", prior_mue_str, model_string_jags, fixed = TRUE) }
         if(is.null(alpha.prior) == FALSE & grepl("alpha[j, t] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
         if(length(alpha.prior) != 2) {stop("provide correct hyper prior values") }
         prior_alphae <- alpha.prior
         prior_alphae_str <- paste("alpha[j, t] ~ dnorm(", prior_alphae[1], ",", prior_alphae[2])
-        model_string_jags <- gsub("alpha[j, t] ~ dnorm(0, 0.0000001", prior_alphae_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("alpha[j, t] ~ dnorm(0, 0.001", prior_alphae_str, model_string_jags, fixed = TRUE) }
     }
     if(length(model_e_random) != 0 & pe_random == 1) {
       if(is.null(mu.a0.prior) == FALSE & grepl("mu_a_hat[t] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
@@ -202,29 +202,29 @@ prior_selection <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(beta0.prior) != 2) {stop("provide correct hyper prior values") }
         prior_muc <- beta0.prior
         prior_muc_str <- paste("beta[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-        model_string_jags <- gsub("beta[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE)
+        model_string_jags <- gsub("beta[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE)
         prior_muc_str <- paste("beta[2] ~ dnorm(",prior_muc[1],",", prior_muc[2])
-        model_string_jags <- gsub("beta[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("beta[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE) }
     } else if(pc_fixed > 1) {
       if(is.null(beta.prior) == FALSE & grepl("beta[1] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("beta[2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
         if(length(beta.prior) != 2) {stop("provide correct hyper prior values") }
         prior_muc <- beta.prior
         prior_muc_str <- paste("beta[1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-        model_string_jags <- gsub("beta[1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE)
+        model_string_jags <- gsub("beta[1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE)
         prior_muc_str <- paste("beta[2] ~ dnorm(",prior_muc[1],",", prior_muc[2])
-        model_string_jags <- gsub("beta[2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("beta[2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE) }
       if(is.null(beta0.prior) == FALSE & grepl("beta[1, 1] ~ ", model_string_jags, fixed = TRUE) == TRUE & grepl("beta[1, 2] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
         if(length(beta0.prior) != 2) {stop("provide correct hyper prior values") }
         prior_muc <- beta0.prior
         prior_muc_str <- paste("beta[1, 1] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-        model_string_jags <- gsub("beta[1, 1] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE)
+        model_string_jags <- gsub("beta[1, 1] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE)
         prior_muc_str <- paste("beta[1, 2] ~ dnorm(", prior_muc[1], ",", prior_muc[2])
-        model_string_jags <- gsub("beta[1, 2] ~ dnorm(0, 0.0000001", prior_muc_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("beta[1, 2] ~ dnorm(0, 0.001", prior_muc_str, model_string_jags, fixed = TRUE) }
         if(is.null(beta.prior) == FALSE & grepl("beta[j, t] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
         if(length(beta.prior) != 2){stop("provide correct hyper prior values") }
         prior_betac <- beta.prior
         prior_betac_str <- paste("beta[j, t] ~ dnorm(", prior_betac[1], ",", prior_betac[2])
-        model_string_jags <- gsub("beta[j, t] ~ dnorm(0, 0.0000001", prior_betac_str, model_string_jags, fixed = TRUE) }
+        model_string_jags <- gsub("beta[j, t] ~ dnorm(0, 0.001", prior_betac_str, model_string_jags, fixed = TRUE) }
     }
     if(length(model_c_random) != 0 & pc_random == 1) {
       if(is.null(mu.b0.prior) == FALSE & grepl("mu_b_hat[t] ~ ", model_string_jags, fixed = TRUE) == TRUE) {
@@ -307,7 +307,7 @@ prior_selection <- function(type, dist_e, dist_c, pe_fixed, pc_fixed , ze_fixed,
         if(length(beta_f.prior) != 2) {stop("provide correct hyper prior values") }
           prior_beta_f <- beta_f.prior
           prior_beta_f_str <- paste("beta_f[t] ~ dnorm(", prior_beta_f[1], ",", prior_beta_f[2])
-          model_string_jags <- gsub("beta_f[t] ~ dnorm(0, 0.0000001", prior_beta_f_str, model_string_jags, fixed = TRUE)
+          model_string_jags <- gsub("beta_f[t] ~ dnorm(0, 0.001", prior_beta_f_str, model_string_jags, fixed = TRUE)
        }
      }
     if(exists("mu.b_f.prior") == TRUE) {

--- a/R/write_hurdle.R
+++ b/R/write_hurdle.R
@@ -160,24 +160,24 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
   
   #priors for mean regression coefficients
   for (j in 2:pe_fixed) {#begin alpha priors effects
-  alpha1[j, 1] ~ dnorm(0, 0.0000001)
-  alpha2[j, 1] ~ dnorm(0, 0.0000001)
+  alpha1[j, 1] ~ dnorm(0, 0.001)
+  alpha2[j, 1] ~ dnorm(0, 0.001)
   alpha1[j, 2] <- 0
   alpha2[j, 2] <- 0
   }#end alpha priors effects
-  alpha1[1, 1] ~ dnorm(0, 0.0000001)
-  alpha2[1, 1] ~ dnorm(0, 0.0000001)
+  alpha1[1, 1] ~ dnorm(0, 0.001)
+  alpha2[1, 1] ~ dnorm(0, 0.001)
   alpha1[1, 2] <- se
   alpha2[1, 2] <- se
   
   for (j in 2:pc_fixed) {#begin beta priors costs
-  beta1[j, 1] ~ dnorm(0, 0.0000001)
-  beta2[j, 1] ~ dnorm(0, 0.0000001)
+  beta1[j, 1] ~ dnorm(0, 0.001)
+  beta2[j, 1] ~ dnorm(0, 0.001)
   beta1[j, 2] <- 0
   beta2[j, 2] <- 0
   }#end beta priors costs
-  beta1[1, 1] ~ dnorm(0, 0.0000001)
-  beta2[1, 1] ~ dnorm(0, 0.0000001)
+  beta1[1, 1] ~ dnorm(0, 0.001)
+  beta2[1, 1] ~ dnorm(0, 0.001)
   beta1[1, 2] <- sc
   beta2[1, 2] <- sc
   
@@ -207,8 +207,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
   ls_e2[2] <- sde
 
   #correlation
-  beta_f1[1] ~ dnorm(0, 0.0000001)
-  beta_f2[1] ~ dnorm(0, 0.0000001)
+  beta_f1[1] ~ dnorm(0, 0.001)
+  beta_f2[1] ~ dnorm(0, 0.001)
   beta_f1[2] <- 0
   beta_f2[2] <- 0
 
@@ -697,8 +697,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
          beta_nons_e1 <- "alpha[1] <- alpha1[1]"
          beta_nons_e2 <- "alpha[2] <- alpha2[1]"
          begin_prior_beta <- "#begin alpha priors effects"
-         prior_beta_e1 <- "alpha1[1] ~ dnorm(0, 0.0000001)"
-         prior_beta_e2 <- "alpha2[1] ~ dnorm(0, 0.0000001)"
+         prior_beta_e1 <- "alpha1[1] ~ dnorm(0, 0.001)"
+         prior_beta_e2 <- "alpha2[1] ~ dnorm(0, 0.001)"
          prior_beta_e1s <- "alpha1[2] <- se"
          prior_beta_e2s <- "alpha2[2] <- se"
          end_prior_beta <- "#end alpha priors effects"
@@ -710,12 +710,12 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
          model_string_jags <- gsub("alpha[j, 1] <- alpha1[j, 1]", beta_nons_e1, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("alpha[j, 2] <- alpha2[j, 1] }", beta_nons_e2, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("for (j in 2:pe_fixed) {#begin alpha priors effects", begin_prior_beta, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("alpha1[j, 1] ~ dnorm(0, 0.0000001)", prior_beta_e1j, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("alpha2[j, 1] ~ dnorm(0, 0.0000001)", prior_beta_e2j, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("alpha1[j, 1] ~ dnorm(0, 0.001)", prior_beta_e1j, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("alpha2[j, 1] ~ dnorm(0, 0.001)", prior_beta_e2j, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("alpha1[j, 2] <- 0", prior_beta_e10, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("alpha2[j, 2] <- 0", prior_beta_e20, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("alpha1[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_e1, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("alpha2[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_e2, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("alpha1[1, 1] ~ dnorm(0, 0.001)", prior_beta_e1, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("alpha2[1, 1] ~ dnorm(0, 0.001)", prior_beta_e2, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("alpha1[1, 2] <- se", prior_beta_e1s, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("alpha2[1, 2] <- se", prior_beta_e2s, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("}#end alpha priors effects", end_prior_beta, model_string_jags, fixed = TRUE)
@@ -745,8 +745,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
          beta_nons_c1 <- "beta[1] <- beta1[1]"
          beta_nons_c2 <- "beta[2] <- beta2[1]"
          begin_prior_beta <- "#begin beta priors costs"
-         prior_beta_c1 <- "beta1[1] ~ dnorm(0, 0.0000001)"
-         prior_beta_c2 <- "beta2[1] ~ dnorm(0, 0.0000001)"
+         prior_beta_c1 <- "beta1[1] ~ dnorm(0, 0.001)"
+         prior_beta_c2 <- "beta2[1] ~ dnorm(0, 0.001)"
          prior_beta_c1s <- "beta1[2] <- sc"
          prior_beta_c2s <- "beta2[2] <- sc"
          end_prior_beta <- "#end beta priors costs"
@@ -758,12 +758,12 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
          model_string_jags <- gsub("beta[j, 1] <- beta1[j, 1]", beta_nons_c1, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("beta[j, 2] <- beta2[j, 1] }", beta_nons_c2, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("for (j in 2:pc_fixed) {#begin beta priors costs", begin_prior_beta, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("beta1[j, 1] ~ dnorm(0, 0.0000001)", prior_beta_c1j, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("beta2[j, 1] ~ dnorm(0, 0.0000001)", prior_beta_c2j, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("beta1[j, 1] ~ dnorm(0, 0.001)", prior_beta_c1j, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("beta2[j, 1] ~ dnorm(0, 0.001)", prior_beta_c2j, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("beta1[j, 2] <- 0", prior_beta_c10, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("beta2[j, 2] <- 0", prior_beta_c20, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("beta1[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_c1, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("beta2[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_c2, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("beta1[1, 1] ~ dnorm(0, 0.001)", prior_beta_c1, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("beta2[1, 1] ~ dnorm(0, 0.001)", prior_beta_c2, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("beta1[1, 2] <- sc", prior_beta_c1s, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("beta2[1, 2] <- sc", prior_beta_c2s, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("}#end beta priors costs", end_prior_beta, model_string_jags, fixed = TRUE)
@@ -886,12 +886,12 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
      model_string_jags <- gsub("p_e[2] <- ilogit(inprod(mean_z_e2_fixed[], gamma_e[, 2]) + inprod(mean_z_e2_random[], mu_g_e_hat[, 2]))", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("gamma_e[1, 1] ~ dlogis(0, 1)", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("gamma_e[1, 2] ~ dlogis(0, 1)", "", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("alpha1[j, 1] ~ dnorm(0, 0.0000001)", "alpha1[j] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("alpha2[j, 1] ~ dnorm(0, 0.0000001)", "alpha2[j] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("alpha1[j, 1] ~ dnorm(0, 0.001)", "alpha1[j] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("alpha2[j, 1] ~ dnorm(0, 0.001)", "alpha2[j] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("alpha1[j, 2] <- 0", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("alpha2[j, 2] <- 0", "", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("alpha1[1, 1] ~ dnorm(0, 0.0000001)", "alpha1[1] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("alpha2[1, 1] ~ dnorm(0, 0.0000001)", "alpha2[1] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("alpha1[1, 1] ~ dnorm(0, 0.001)", "alpha1[1] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("alpha2[1, 1] ~ dnorm(0, 0.001)", "alpha2[1] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("alpha1[1, 2] <- se", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("alpha2[1, 2] <- se", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("ls_e1[1] ~ dunif(-5, 10)", "ls_e1 ~ dunif(-5, 10)", model_string_jags, fixed = TRUE)
@@ -1301,8 +1301,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
          beta_nons_e1 <- "alpha[1] <- alpha1[1]"
          beta_nons_e2 <- "alpha[2] <- alpha2[1]"
          begin_prior_beta <- "#begin alpha priors effects"
-         prior_beta_e1 <- "alpha1[1] ~ dnorm(0, 0.0000001)"
-         prior_beta_e2 <- "alpha2[1] ~ dnorm(0, 0.0000001)"
+         prior_beta_e1 <- "alpha1[1] ~ dnorm(0, 0.001)"
+         prior_beta_e2 <- "alpha2[1] ~ dnorm(0, 0.001)"
          end_prior_beta <- "#end beta priors effects"
          model_string_jags <- gsub("inprod(X1_e_fixed[i, ], alpha1[])", inprod_e1, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("inprod(X2_e_fixed[i, ], alpha2[])", inprod_e2, model_string_jags, fixed = TRUE)
@@ -1312,12 +1312,12 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
          model_string_jags <- gsub("alpha[j, 1] <- alpha1[j]", beta_nons_e1, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("alpha[j, 2] <- alpha2[j] }", beta_nons_e2, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("for (j in 2:pe_fixed) {#begin alpha priors effects", begin_prior_beta, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("alpha1[j] ~ dnorm(0, 0.0000001)", prior_beta_e1j, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("alpha2[j] ~ dnorm(0, 0.0000001)", prior_beta_e2j, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("alpha1[j] ~ dnorm(0, 0.001)", prior_beta_e1j, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("alpha2[j] ~ dnorm(0, 0.001)", prior_beta_e2j, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("alpha1[j] <- 0", prior_beta_e10, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("alpha2[j] <- 0", prior_beta_e20, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("alpha1[1] ~ dnorm(0, 0.0000001)", prior_beta_e1, model_string_jags, fixed = TRUE)
-         model_string_jags <- gsub("alpha2[1] ~ dnorm(0, 0.0000001)", prior_beta_e2, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("alpha1[1] ~ dnorm(0, 0.001)", prior_beta_e1, model_string_jags, fixed = TRUE)
+         model_string_jags <- gsub("alpha2[1] ~ dnorm(0, 0.001)", prior_beta_e2, model_string_jags, fixed = TRUE)
          model_string_jags <- gsub("}#end alpha priors effects", end_prior_beta, model_string_jags, fixed = TRUE)
        }
        if(length(model_e_random) != 0 & pe_random == 1) {
@@ -1345,8 +1345,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
        beta_nons_c1 <- "beta[1] <- beta1[1]"
        beta_nons_c2 <- "beta[2] <- beta2[1]"
        begin_prior_beta <- "#begin beta priors costs"
-       prior_beta_c1 <- "beta1[1] ~ dnorm(0, 0.0000001)"
-       prior_beta_c2 <- "beta2[1] ~ dnorm(0, 0.0000001)"
+       prior_beta_c1 <- "beta1[1] ~ dnorm(0, 0.001)"
+       prior_beta_c2 <- "beta2[1] ~ dnorm(0, 0.001)"
        prior_beta_c1s <- "beta1[2] <- sc"
        prior_beta_c2s <- "beta2[2] <- sc"
        end_prior_beta <- "#end beta priors costs"
@@ -1358,12 +1358,12 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
        model_string_jags <- gsub("beta[j, 1] <- beta1[j, 1]", beta_nons_c1, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("beta[j, 2] <- beta2[j, 1] }", beta_nons_c2, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("for (j in 2:pc_fixed) {#begin beta priors costs", begin_prior_beta, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("beta1[j, 1] ~ dnorm(0, 0.0000001)", prior_beta_c1j, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("beta2[j, 1] ~ dnorm(0, 0.0000001)", prior_beta_c2j, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("beta1[j, 1] ~ dnorm(0, 0.001)", prior_beta_c1j, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("beta2[j, 1] ~ dnorm(0, 0.001)", prior_beta_c2j, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("beta1[j, 2] <- 0", prior_beta_c10, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("beta2[j, 2] <- 0", prior_beta_c20, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("beta1[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_c1, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("beta2[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_c2, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("beta1[1, 1] ~ dnorm(0, 0.001)", prior_beta_c1, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("beta2[1, 1] ~ dnorm(0, 0.001)", prior_beta_c2, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("beta1[1, 2] <- sc", prior_beta_c1s, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("beta2[1, 2] <- sc", prior_beta_c2s, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("}#end beta priors costs", end_prior_beta, model_string_jags, fixed = TRUE)
@@ -1450,12 +1450,12 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
      model_string_jags <- gsub("p_c[2] <- ilogit(inprod(mean_z_c2_fixed[], gamma_c[, 2]) + inprod(mean_z_c2_random[], mu_g_c_hat[, 2]))", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("gamma_c[1, 1] ~ dlogis(0, 1)", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("gamma_c[1, 2] ~ dlogis(0, 1)", "", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("beta1[j, 1] ~ dnorm(0, 0.0000001)", "beta1[j] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("beta2[j, 1] ~ dnorm(0, 0.0000001)", "beta2[j] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("beta1[j, 1] ~ dnorm(0, 0.001)", "beta1[j] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("beta2[j, 1] ~ dnorm(0, 0.001)", "beta2[j] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("beta1[j, 2] <- 0", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("beta2[j, 2] <- 0", "", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("beta1[1, 1] ~ dnorm(0, 0.0000001)", "beta1[1] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("beta2[1, 1] ~ dnorm(0, 0.0000001)", "beta2[1] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("beta1[1, 1] ~ dnorm(0, 0.001)", "beta1[1] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("beta2[1, 1] ~ dnorm(0, 0.001)", "beta2[1] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("beta1[1, 2] <- sc", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("beta2[1, 2] <- sc", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("ls_c1[1] ~ dunif(-5, 10)", "ls_c1 ~ dunif(-5, 10)", model_string_jags, fixed = TRUE)
@@ -1465,8 +1465,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
      model_string_jags <- gsub("for (j in 2:zc_fixed) {#begin gamma priors costs", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("for(t in 1:2) {gamma_c[j, t] ~ dnorm(0, 0.01) }", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("}#end gamma priors costs", "", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("beta_f1[1] ~ dnorm(0, 0.0000001)", "beta_f[1] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
-     model_string_jags <- gsub("beta_f2[1] ~ dnorm(0, 0.0000001)", "beta_f[2] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("beta_f1[1] ~ dnorm(0, 0.001)", "beta_f[1] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
+     model_string_jags <- gsub("beta_f2[1] ~ dnorm(0, 0.001)", "beta_f[2] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("beta_f1[2] <- 0", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("beta_f2[2] <- 0", "", model_string_jags, fixed = TRUE)
      model_string_jags <- gsub("beta_f[1] <- beta_f1[1]", "", model_string_jags, fixed = TRUE)
@@ -1897,8 +1897,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
        beta_nons_e1 <- "alpha[1] <- alpha1[1]"
        beta_nons_e2 <- "alpha[2] <- alpha2[1]"
        begin_prior_beta <- "#begin alpha priors effects"
-       prior_beta_e1 <- "alpha1[1] ~ dnorm(0, 0.0000001)"
-       prior_beta_e2 <- "alpha2[1] ~ dnorm(0, 0.0000001)"
+       prior_beta_e1 <- "alpha1[1] ~ dnorm(0, 0.001)"
+       prior_beta_e2 <- "alpha2[1] ~ dnorm(0, 0.001)"
        prior_beta_e1s <- "alpha1[2] <- se"
        prior_beta_e2s <- "alpha2[2] <- se"
        end_prior_beta <- "#end alpha priors effects"
@@ -1910,12 +1910,12 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
        model_string_jags <- gsub("alpha[j, 1] <- alpha1[j, 1]", beta_nons_e1, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("alpha[j, 2] <- alpha2[j, 1] }", beta_nons_e2, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("for (j in 2:pe_fixed) {#begin alpha priors effects", begin_prior_beta, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("alpha1[j, 1] ~ dnorm(0, 0.0000001)", prior_beta_e1j, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("alpha2[j, 1] ~ dnorm(0, 0.0000001)", prior_beta_e2j, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("alpha1[j, 1] ~ dnorm(0, 0.001)", prior_beta_e1j, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("alpha2[j, 1] ~ dnorm(0, 0.001)", prior_beta_e2j, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("alpha1[j, 2] <- 0", prior_beta_e10, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("alpha2[j, 2] <- 0", prior_beta_e20, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("alpha1[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_e1, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("alpha2[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_e2, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("alpha1[1, 1] ~ dnorm(0, 0.001)", prior_beta_e1, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("alpha2[1, 1] ~ dnorm(0, 0.001)", prior_beta_e2, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("alpha1[1, 2] <- se", prior_beta_e1s, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("alpha2[1, 2] <- se", prior_beta_e2s, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("}#end alpha priors effects", end_prior_beta, model_string_jags, fixed = TRUE)
@@ -1945,8 +1945,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
        beta_nons_c1 <- "beta[1] <- beta1[1]"
        beta_nons_c2 <- "beta[2] <- beta2[1]"
        begin_prior_beta <- "#begin beta priors costs"
-       prior_beta_c1 <- "beta1[1] ~ dnorm(0, 0.0000001)"
-       prior_beta_c2 <- "beta2[1] ~ dnorm(0, 0.0000001)"
+       prior_beta_c1 <- "beta1[1] ~ dnorm(0, 0.001)"
+       prior_beta_c2 <- "beta2[1] ~ dnorm(0, 0.001)"
        end_prior_beta <- "#end beta priors costs"
        model_string_jags <- gsub("inprod(X1_c_fixed[i, ], beta1[])", inprod_c1, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("inprod(X2_c_fixed[i, ], beta2[])", inprod_c2, model_string_jags, fixed = TRUE)
@@ -1956,12 +1956,12 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
        model_string_jags <- gsub("beta[j, 1] <- beta1[j]", beta_nons_c1, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("beta[j, 2] <- beta2[j] }", beta_nons_c2, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("for (j in 2:pc_fixed) {#begin beta priors costs", begin_prior_beta, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("beta1[j] ~ dnorm(0, 0.0000001)", prior_beta_c1j, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("beta2[j] ~ dnorm(0, 0.0000001)", prior_beta_c2j, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("beta1[j] ~ dnorm(0, 0.001)", prior_beta_c1j, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("beta2[j] ~ dnorm(0, 0.001)", prior_beta_c2j, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("beta1[j] <- 0", prior_beta_c10, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("beta2[j] <- 0", prior_beta_c20, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("beta1[1] ~ dnorm(0, 0.0000001)", prior_beta_c1, model_string_jags, fixed = TRUE)
-       model_string_jags <- gsub("beta2[1] ~ dnorm(0, 0.0000001)", prior_beta_c2, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("beta1[1] ~ dnorm(0, 0.001)", prior_beta_c1, model_string_jags, fixed = TRUE)
+       model_string_jags <- gsub("beta2[1] ~ dnorm(0, 0.001)", prior_beta_c2, model_string_jags, fixed = TRUE)
        model_string_jags <- gsub("}#end beta priors costs", end_prior_beta, model_string_jags, fixed = TRUE)
      }
      if(length(model_c_random) != 0 & pc_random == 1) {
@@ -2021,8 +2021,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
     if(is.null(sc) == FALSE) {
     model_string_jags <- gsub(" + beta_f1[d_cost1[i] + 1] * (eff1[i] - mu_e[1])", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub(" + beta_f2[d_cost2[i] + 1] * (eff2[i] - mu_e[2])", "", model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_f1[1] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_f2[1] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_f1[1] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_f2[1] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_f1[2] <- 0", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_f2[2] <- 0", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_f[1] <- beta_f1[1]", "", model_string_jags, fixed = TRUE)
@@ -2031,8 +2031,8 @@ write_hurdle <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed, zc
     } else if(is.null(sc) == TRUE) {
       model_string_jags <- gsub(" + beta_f[1] * (eff1[i] - mu_e[1])", "", model_string_jags, fixed = TRUE)
       model_string_jags <- gsub(" + beta_f[2] * (eff2[i] - mu_e[2])", "", model_string_jags, fixed = TRUE)
-      model_string_jags <- gsub("beta_f[1] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
-      model_string_jags <- gsub("beta_f[2] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
+      model_string_jags <- gsub("beta_f[1] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
+      model_string_jags <- gsub("beta_f[2] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
       model_string_jags <- gsub("#correlation", "", model_string_jags, fixed = TRUE)
       model_string_jags <- gsub("beta_f[1] <- beta_f1[1]", "", model_string_jags, fixed = TRUE)
       model_string_jags <- gsub("beta_f[2] <- beta_f2[1]", "", model_string_jags, fixed = TRUE)

--- a/R/write_long_miss.R
+++ b/R/write_long_miss.R
@@ -223,18 +223,18 @@ write_long_miss <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
   #priors for mean regression coefficients
   for(time in 1:max_time) {# loop through time alpha
   for (j in 2:pe_fixed) {#begin alpha priors effects
-  for(t in 1:2) {alpha[j, t, time] ~ dnorm(0, 0.0000001) }
+  for(t in 1:2) {alpha[j, t, time] ~ dnorm(0, 0.001) }
   }#end alpha priors effects
-  alpha[1, 1, time] ~ dnorm(0, 0.0000001)
-  alpha[1, 2, time] ~ dnorm(0, 0.0000001)
+  alpha[1, 1, time] ~ dnorm(0, 0.001)
+  alpha[1, 2, time] ~ dnorm(0, 0.001)
   }#end alpha loop time
 
   for(time in 1:max_time) {# loop through time beta
   for (j in 2:pc_fixed) {#begin beta priors costs
-  for(t in 1:2) {beta[j, t, time] ~ dnorm(0, 0.0000001) }
+  for(t in 1:2) {beta[j, t, time] ~ dnorm(0, 0.001) }
   }#end beta priors costs
-  beta[1, 1, time] ~ dnorm(0, 0.0000001)
-  beta[1, 2, time] ~ dnorm(0, 0.0000001)
+  beta[1, 1, time] ~ dnorm(0, 0.001)
+  beta[1, 2, time] ~ dnorm(0, 0.001)
   }#end beta loop time
 
   #priors for mean regression random coefficients
@@ -267,13 +267,13 @@ write_long_miss <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
   ls_e[t, time] ~ dunif(-5, 10)
 
   #correlation
-  beta_f[t, time] ~ dnorm(0, 0.0000001)
+  beta_f[t, time] ~ dnorm(0, 0.001)
   
   #time dependence
-  beta_te[t, time] ~ dnorm(0, 0.0000001)
-  beta_tc[t, time] ~ dnorm(0, 0.0000001)
-  alpha_te[t, time] ~ dnorm(0, 0.0000001)
-  alpha_tc[t, time] ~ dnorm(0, 0.0000001)
+  beta_te[t, time] ~ dnorm(0, 0.001)
+  beta_tc[t, time] ~ dnorm(0, 0.001)
+  alpha_te[t, time] ~ dnorm(0, 0.001)
+  alpha_tc[t, time] ~ dnorm(0, 0.001)
 
   # mean and sd mean regression random coefficients priors
   for(j in 1:pc_random) {mu_b_hat[j, t, time] ~ dnorm(0, 0.001)
@@ -1009,7 +1009,7 @@ write_long_miss <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
     model_string_jags <- gsub("+ beta_f[2, 1] * (eff2[i, 1] - mu_e[2, 1])", "", model_string_jags, fixed = TRUE)  
     model_string_jags <- gsub("+ beta_f[1, time] * (eff1[i, time] - mu_e[1, time])", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("+ beta_f[2, time] * (eff2[i, time] - mu_e[2, time])", "", model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_f[t, time] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_f[t, time] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("#correlation", "", model_string_jags, fixed = TRUE)
   } 
  if(ind_time_fixed == TRUE | time_dep == "none") {
@@ -1017,10 +1017,10 @@ write_long_miss <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
    model_string_jags <- gsub("+ alpha_te[1, time] * (eff1[i, time - 1] - mu_e[1, time - 1]) + alpha_tc[1, time] * (cost1[i, time - 1] - mu_c[1, time - 1])", "", model_string_jags, fixed = TRUE)  
    model_string_jags <- gsub("+ beta_te[2, time] * (eff2[i, time - 1] - mu_e[2, time - 1]) + beta_tc[2, time] * (cost2[i, time - 1] - mu_c[2, time - 1])", "", model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("+ alpha_te[2, time] * (eff2[i, time - 1] - mu_e[2, time - 1]) + alpha_tc[2, time] * (cost2[i, time - 1] - mu_c[2, time - 1])", "", model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("beta_te[t, time] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("beta_tc[t, time] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("alpha_te[t, time] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("alpha_tc[t, time] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("beta_te[t, time] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("beta_tc[t, time] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("alpha_te[t, time] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("alpha_tc[t, time] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("#time dependence", "", model_string_jags, fixed = TRUE)
  }  
   if(dist_c == "norm") {
@@ -1270,8 +1270,8 @@ write_long_miss <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
    begin_prior_beta <- "#begin alpha priors effects"
    prior_beta <- "#"
    end_prior_beta <- "#end alpha priors effects"
-   prior_beta_e1 <- "alpha[1, time] ~ dnorm(0, 0.0000001)"
-   prior_beta_e2 <- "alpha[2, time] ~ dnorm(0, 0.0000001)"
+   prior_beta_e1 <- "alpha[1, time] ~ dnorm(0, 0.001)"
+   prior_beta_e2 <- "alpha[2, time] ~ dnorm(0, 0.001)"
    model_string_jags <- gsub("inprod(X1_e_fixed[i, ], alpha[, 1, 1])", inprod_e1_base, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(X1_e_fixed[i, ], alpha[, 1, time])", inprod_e1, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(X2_e_fixed[i, ], alpha[, 2, 1])", inprod_e2_base, model_string_jags, fixed = TRUE)
@@ -1279,10 +1279,10 @@ write_long_miss <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
    model_string_jags <- gsub("inprod(mean_cov_e1_fixed[], alpha[, 1, time])", inprod_mean_e1, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(mean_cov_e2_fixed[], alpha[, 2, time])", inprod_mean_e2, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("for (j in 2:pe_fixed) {#begin alpha priors effects", begin_prior_beta, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("for(t in 1:2) {alpha[j, t, time] ~ dnorm(0, 0.0000001) }", prior_beta, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("for(t in 1:2) {alpha[j, t, time] ~ dnorm(0, 0.001) }", prior_beta, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("}#end alpha priors effects", end_prior_beta, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("alpha[1, 1, time] ~ dnorm(0, 0.0000001)", prior_beta_e1, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("alpha[1, 2, time] ~ dnorm(0, 0.0000001)", prior_beta_e2, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("alpha[1, 1, time] ~ dnorm(0, 0.001)", prior_beta_e1, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("alpha[1, 2, time] ~ dnorm(0, 0.001)", prior_beta_e2, model_string_jags, fixed = TRUE)
    }
    if(length(model_e_random) != 0 & pe_random == 1) {
        model_string_jags <- gsub("inprod(X1_e_random[i, ], a1[, clus1_e[i], 1])", "X1_e_random[i] * a1[clus1_e[i], 1]", model_string_jags, fixed = TRUE)
@@ -1312,8 +1312,8 @@ write_long_miss <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
    begin_prior_beta <- "#begin beta priors costs"
    prior_beta <- "#"
    end_prior_beta <- "#end beta priors costs"
-   prior_beta_c1 <- "beta[1, time] ~ dnorm(0, 0.0000001)"
-   prior_beta_c2 <- "beta[2, time] ~ dnorm(0, 0.0000001)"
+   prior_beta_c1 <- "beta[1, time] ~ dnorm(0, 0.001)"
+   prior_beta_c2 <- "beta[2, time] ~ dnorm(0, 0.001)"
    model_string_jags <- gsub("inprod(X1_c_fixed[i, ], beta[, 1, 1])", inprod_c1_base, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(X1_c_fixed[i, ], beta[, 1, time])", inprod_c1, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(X2_c_fixed[i, ], beta[, 2, 1])", inprod_c2_base, model_string_jags, fixed = TRUE)
@@ -1321,10 +1321,10 @@ write_long_miss <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
    model_string_jags <- gsub("inprod(mean_cov_c1_fixed[], beta[, 1, time])", inprod_mean_c1, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(mean_cov_c2_fixed[], beta[, 2, time])", inprod_mean_c2, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("for (j in 2:pc_fixed) {#begin beta priors costs", begin_prior_beta, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("for(t in 1:2) {beta[j, t, time] ~ dnorm(0, 0.0000001) }", prior_beta, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("for(t in 1:2) {beta[j, t, time] ~ dnorm(0, 0.001) }", prior_beta, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("}#end beta priors costs", end_prior_beta,model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("beta[1, 1, time] ~ dnorm(0, 0.0000001)", prior_beta_c1, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("beta[1, 2, time] ~ dnorm(0, 0.0000001)", prior_beta_c2, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("beta[1, 1, time] ~ dnorm(0, 0.001)", prior_beta_c1, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("beta[1, 2, time] ~ dnorm(0, 0.001)", prior_beta_c2, model_string_jags, fixed = TRUE)
    }
    if(pc_fixed == 0 & ind_fixed == FALSE) {
    prior_beta <- "#"
@@ -1346,10 +1346,10 @@ write_long_miss <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
    model_string_jags <- gsub("inprod(mean_cov_c2_fixed[], beta[, 2, time])", "beta_f[2, time] * (mean(eff2[, time]) - mu_e[2, time])", model_string_jags, fixed = TRUE)
    }
    model_string_jags <- gsub("for (j in 2:pc_fixed) {#begin beta priors costs", "", model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("for(t in 1:2) {beta[j, t, time] ~ dnorm(0, 0.0000001) }", prior_beta, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("for(t in 1:2) {beta[j, t, time] ~ dnorm(0, 0.001) }", prior_beta, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("}#end beta priors costs", end_prior_beta,model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("beta[1, 1, time] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("beta[1, 2, time] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("beta[1, 1, time] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("beta[1, 2, time] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("for(time in 1:max_time) {# loop through time beta", "", model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("#end beta priors costs", "", model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("}#end beta loop time", "", model_string_jags, fixed = TRUE)

--- a/R/write_pattern.R
+++ b/R/write_pattern.R
@@ -147,42 +147,42 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
   
   #priors for mean regression coefficients
   for (j in 2:pe_fixed) {#begin alpha priors effects in each pattern
-  alpha_p1[j, 1] ~ dnorm(0, 0.0000001)
+  alpha_p1[j, 1] ~ dnorm(0, 0.001)
   alpha_p1[j, 2] <- alpha_p1[j, 1]
-  alpha_p1[j, 3] ~ dnorm(0, 0.0000001)
+  alpha_p1[j, 3] ~ dnorm(0, 0.001)
   alpha_p1[j, 4] <- alpha_p1[j, 1]
-  alpha_p2[j, 1] ~ dnorm(0, 0.0000001)
+  alpha_p2[j, 1] ~ dnorm(0, 0.001)
   alpha_p2[j, 2] <- alpha_p2[j, 1]
-  alpha_p2[j, 3] ~ dnorm(0, 0.0000001)
+  alpha_p2[j, 3] ~ dnorm(0, 0.001)
   alpha_p2[j, 4] <- alpha_p2[j, 1]
   }#end alpha priors effects
-  alpha_p1[1, 1] ~ dnorm(0, 0.0000001)
+  alpha_p1[1, 1] ~ dnorm(0, 0.001)
   alpha_p1[1, 2] <- alpha_p1[1, 1]
-  alpha_p1[1, 3] ~ dnorm(0, 0.0000001)
+  alpha_p1[1, 3] ~ dnorm(0, 0.001)
   alpha_p1[1, 4] <- alpha_p1[1, 1]
   
-  alpha_p2[1, 1] ~ dnorm(0, 0.0000001)
+  alpha_p2[1, 1] ~ dnorm(0, 0.001)
   alpha_p2[1, 2] <- alpha_p2[1, 1]
-  alpha_p2[1, 3] ~ dnorm(0, 0.0000001)
+  alpha_p2[1, 3] ~ dnorm(0, 0.001)
   alpha_p2[1, 4] <- alpha_p2[1, 1]
 
   for (j in 2:pc_fixed) {#begin beta priors costs
-  beta_p1[j, 1] ~ dnorm(0, 0.0000001)
-  beta_p1[j, 2] ~ dnorm(0, 0.0000001)
+  beta_p1[j, 1] ~ dnorm(0, 0.001)
+  beta_p1[j, 2] ~ dnorm(0, 0.001)
   beta_p1[j, 3] <- beta_p1[j, 1]
   beta_p1[j, 4] <- beta_p1[j, 1]
-  beta_p2[j, 1] ~ dnorm(0, 0.0000001)
-  beta_p2[j, 2] ~ dnorm(0, 0.0000001)
+  beta_p2[j, 1] ~ dnorm(0, 0.001)
+  beta_p2[j, 2] ~ dnorm(0, 0.001)
   beta_p2[j, 3] <- beta_p2[j, 1]
   beta_p2[j, 4] <- beta_p2[j, 1]
   }#end beta priors costs
-  beta_p1[1, 1] ~ dnorm(0, 0.0000001)
-  beta_p1[1, 2] ~ dnorm(0, 0.0000001)
+  beta_p1[1, 1] ~ dnorm(0, 0.001)
+  beta_p1[1, 2] ~ dnorm(0, 0.001)
   beta_p1[1, 3] <- beta_p1[1, 1]
   beta_p1[1, 4] <- beta_p1[1, 1]
   
-  beta_p2[1, 1] ~ dnorm(0, 0.0000001)
-  beta_p2[1, 2] ~ dnorm(0, 0.0000001)
+  beta_p2[1, 1] ~ dnorm(0, 0.001)
+  beta_p2[1, 2] ~ dnorm(0, 0.001)
   beta_p2[1, 3] <- beta_p2[1, 1]
   beta_p2[1, 4] <- beta_p2[1, 1]
   
@@ -223,12 +223,12 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
   ls_e_p2[4] <- ls_e_p2[1]
 
   #correlation
-  beta_f_p1[1] ~ dnorm(0, 0.0000001) 
+  beta_f_p1[1] ~ dnorm(0, 0.001) 
   beta_f_p1[2] <- beta_f_p1[1]
   beta_f_p1[3] <- beta_f_p1[1] 
   beta_f_p1[4] <- beta_f_p1[1]
 
-  beta_f_p2[1] ~ dnorm(0, 0.0000001)
+  beta_f_p2[1] ~ dnorm(0, 0.001)
   beta_f_p2[2] <- beta_f_p2[1]
   beta_f_p2[3] <- beta_f_p2[1]
   beta_f_p2[4] <- beta_f_p2[1]
@@ -383,11 +383,11 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
   if(ind_fixed == TRUE) {
     model_string_jags <- gsub(" + beta_f_p1[d1[i]] * (eff1[i] - meane_p1[d1[i]])", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub(" + beta_f_p2[d2[i]] * (eff2[i] - meane_p2[d2[i]])", "", model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_f_p1[1] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_f_p1[1] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_f_p1[2] <- beta_f_p1[1]", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_f_p1[3] <- beta_f_p1[1]", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_f_p1[4] <- beta_f_p1[1]", "", model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_f_p2[1] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_f_p2[1] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_f_p2[2] <- beta_f_p2[1]", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_f_p2[3] <- beta_f_p2[1]", "", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_f_p2[4] <- beta_f_p2[1]", "", model_string_jags, fixed = TRUE)
@@ -762,30 +762,30 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
     begin_prior_beta <- "#begin alpha priors effects"
     prior_beta <- "#"
     end_prior_beta <- "#end alpha priors effects"
-    prior_beta_e1_1 <- "alpha_p1[1] ~ dnorm(0, 0.0000001)"
-    prior_beta_e1_3 <- "alpha_p1[3] ~ dnorm(0, 0.0000001)"
-    prior_beta_e2_1 <- "alpha_p2[1] ~ dnorm(0, 0.0000001)"
-    prior_beta_e2_3 <- "alpha_p2[3] ~ dnorm(0, 0.0000001)"
+    prior_beta_e1_1 <- "alpha_p1[1] ~ dnorm(0, 0.001)"
+    prior_beta_e1_3 <- "alpha_p1[3] ~ dnorm(0, 0.001)"
+    prior_beta_e2_1 <- "alpha_p2[1] ~ dnorm(0, 0.001)"
+    prior_beta_e2_3 <- "alpha_p2[3] ~ dnorm(0, 0.001)"
     model_string_jags <- gsub("inprod(X1_e_fixed[i, ], alpha_p1[, d1[i]])", inprod_e1, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("inprod(X2_e_fixed[i, ], alpha_p2[, d2[i]])", inprod_e2, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("inprod(mean_cov_e1_fixed[], alpha_p1[, d])", inprod_mean_e1, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("inprod(mean_cov_e2_fixed[], alpha_p2[, d])", inprod_mean_e2, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("for (j in 2:pe_fixed) {#begin alpha priors effects", begin_prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001)", prior_beta, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001)", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("alpha_p1[j, 2] <- alpha_p1[j, 1]", prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.0000001)", prior_beta, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.001)", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("alpha_p1[j, 4] <- alpha_p1[j, 1]", prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001)", prior_beta, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001)", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("alpha_p2[j, 2] <- alpha_p2[j, 1]", prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.0000001)", prior_beta, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.001)", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("alpha_p2[j, 4] <- alpha_p2[j, 1]", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("}#end alpha priors effects", end_prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_e1_1, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.0000001)", prior_beta_e1_3, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001)", prior_beta_e1_1, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.001)", prior_beta_e1_3, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("alpha_p1[1, 2] <- alpha_p1[1, 1]", "alpha_p1[2] <- alpha_p1[1]", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("alpha_p1[1, 4] <- alpha_p1[1, 1]", "alpha_p1[4] <- alpha_p1[1]", model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_e2_1, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.0000001)", prior_beta_e2_3, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001)", prior_beta_e2_1, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.001)", prior_beta_e2_3, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("alpha_p2[1, 2] <- alpha_p2[1, 1]", "alpha_p2[2] <- alpha_p2[1]", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("alpha_p2[1, 4] <- alpha_p2[1, 1]", "alpha_p2[4] <- alpha_p2[1]", model_string_jags, fixed = TRUE)
     if(restriction == "AC"){
@@ -823,30 +823,30 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
     begin_prior_beta <- "#begin beta priors costs"
     prior_beta <- "#"
     end_prior_beta <- "#end beta priors costs"
-    prior_beta_c1_1 <- "beta_p1[1] ~ dnorm(0, 0.0000001)"
-    prior_beta_c1_2 <- "beta_p1[2] ~ dnorm(0, 0.0000001)"
-    prior_beta_c2_1 <- "beta_p2[1] ~ dnorm(0, 0.0000001)"
-    prior_beta_c2_2 <- "beta_p2[2] ~ dnorm(0, 0.0000001)"
+    prior_beta_c1_1 <- "beta_p1[1] ~ dnorm(0, 0.001)"
+    prior_beta_c1_2 <- "beta_p1[2] ~ dnorm(0, 0.001)"
+    prior_beta_c2_1 <- "beta_p2[1] ~ dnorm(0, 0.001)"
+    prior_beta_c2_2 <- "beta_p2[2] ~ dnorm(0, 0.001)"
     model_string_jags <- gsub("inprod(X1_c_fixed[i, ], beta_p1[, d1[i]])", inprod_c1, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("inprod(X2_c_fixed[i, ], beta_p2[, d2[i]])", inprod_c2, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("inprod(mean_cov_c1_fixed[], beta_p1[, d])", inprod_mean_c1, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("inprod(mean_cov_c2_fixed[], beta_p2[, d])", inprod_mean_c2, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("for (j in 2:pc_fixed) {#begin beta priors costs", begin_prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001)", prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001)", prior_beta, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001)", prior_beta, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001)", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_p1[j, 3] <- beta_p1[j, 1]", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_p1[j, 4] <- beta_p1[j, 1]", prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001)", prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001)", prior_beta, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001)", prior_beta, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001)", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_p2[j, 3] <- beta_p2[j, 1]", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_p2[j, 4] <- beta_p2[j, 1]", prior_beta, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("}#end beta priors costs", end_prior_beta, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_c1_1, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001)", prior_beta_c1_2, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001)", prior_beta_c1_1, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001)", prior_beta_c1_2, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_p1[1, 3] <- beta_p1[1, 1]", "beta_p1[3] <- beta_p1[1]", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_p1[1, 4] <- beta_p1[1, 1]", "beta_p1[4] <- beta_p1[1]", model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_c2_1, model_string_jags, fixed = TRUE)
-    model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001)", prior_beta_c2_2, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001)", prior_beta_c2_1, model_string_jags, fixed = TRUE)
+    model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001)", prior_beta_c2_2, model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_p2[1, 3] <- beta_p2[1, 1]", "beta_p2[3] <- beta_p2[1]", model_string_jags, fixed = TRUE)
     model_string_jags <- gsub("beta_p2[1, 4] <- beta_p2[1, 1]", "beta_p2[4] <- beta_p2[1]", model_string_jags, fixed = TRUE)
     if(restriction == "AC"){
@@ -904,10 +904,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
         d1 <- ifelse(d1 == 4, 3, d1)
         if(type == "MNAR" | type == "MNAR_eff") {model_string_jags <- gsub("mu_e_p1[3] <- meane_p1[3]", "mu_e_p1[3] <- meane_p1[3] + Delta_e[1]", model_string_jags, fixed = TRUE) }
         if(pe_fixed > 1) {
-          model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.0000001)", "alpha_p1[1, 3] <- alpha_p1[1, 1]", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.0000001)", "alpha_p1[j, 3] <- alpha_p1[j, 1]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.001)", "alpha_p1[1, 3] <- alpha_p1[1, 1]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.001)", "alpha_p1[j, 3] <- alpha_p1[j, 1]", model_string_jags, fixed = TRUE) 
         }
-        if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.0000001)", "alpha_p1[3] <- alpha_p1[1]", model_string_jags, fixed = TRUE) }
+        if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.001)", "alpha_p1[3] <- alpha_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_e == "norm") {model_string_jags <- gsub("ls_e_p1[3] ~ dunif(-5, 10)", "ls_e_p1[3] <- ls_e_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_e == "beta") {model_string_jags <- gsub("s_e_p1[3] ~ dunif(0, sqrt(meane_p1[3] * (1 - meane_p1[3])))", "s_e_p1[3] <- s_e_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_e %in% c("gamma", "logis")) {model_string_jags <- gsub("s_e_p1[3] ~ dunif(0, 10000)", "s_e_p1[3] <- s_e_p1[1]", model_string_jags, fixed = TRUE) }
@@ -920,10 +920,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
         d1 <- ifelse(d1 == 4, 2, d1)
         if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p1[2] <- meanc_p1[2]", "mu_c_p1[2] <- meanc_p1[2] + Delta_c[1]", model_string_jags, fixed = TRUE) }
         if(pc_fixed > 1) {
-          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001)", "beta_p1[1, 2] <- beta_p1[1, 1]", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001)", "beta_p1[j, 2] <- beta_p1[j, 1]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001)", "beta_p1[1, 2] <- beta_p1[1, 1]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001)", "beta_p1[j, 2] <- beta_p1[j, 1]", model_string_jags, fixed = TRUE) 
         }
-        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.0000001)", "beta_p1[2] <- beta_p1[1]", model_string_jags, fixed = TRUE) }
+        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.001)", "beta_p1[2] <- beta_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p1[2] ~ dunif(-5, 10)", "ls_c_p1[2] <- ls_c_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p1[2] ~ dunif(0, 100)", "ls_c_p1[2] <- ls_c_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p1[2] ~ dunif(0, 10000)", "s_c_p1[2] <- s_c_p1[1]", model_string_jags, fixed = TRUE) }
@@ -935,10 +935,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
       if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p1[3] <- meanc_p1[3] + Delta_c[1]", "", model_string_jags, fixed = TRUE) }
       if(type == "MNAR" | type == "MNAR_eff") {model_string_jags <- gsub("mu_e_p1[3] <- meane_p1[3]", "", model_string_jags, fixed = TRUE) }
       if(pe_fixed > 1) {
-        model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
-        model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
       }
-      if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) }
+      if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) }
       if(pc_fixed > 1) {
         model_string_jags <- gsub("beta_p1[1, 3] <- beta_p1[1, 1]", "", model_string_jags, fixed = TRUE) 
         model_string_jags <- gsub("beta_p1[j, 3] <- beta_p1[j, 1]", "", model_string_jags, fixed = TRUE) 
@@ -959,18 +959,18 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
         d1 <- ifelse(d1 == 3, 2, d1)
         if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p1[2] <- meanc_p1[2]", "mu_c_p1[2] <- meanc_p1[2] + Delta_c[1]", model_string_jags, fixed = TRUE) }
         if(pc_fixed > 1) {
-          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001)", "beta_p1[1, 2] <- beta_p1[1, 1]", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001)", "beta_p1[j, 2] <- beta_p1[j, 1]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001)", "beta_p1[1, 2] <- beta_p1[1, 1]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001)", "beta_p1[j, 2] <- beta_p1[j, 1]", model_string_jags, fixed = TRUE) 
         }
-        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.0000001)", "beta_p1[2] <- beta_p1[1]", model_string_jags, fixed = TRUE) }
+        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.001)", "beta_p1[2] <- beta_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p1[2] ~ dunif(-5, 10)", "ls_c_p1[2] <- ls_c_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p1[2] ~ dunif(0, 100)", "ls_c_p1[2] <- ls_c_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p1[2] ~ dunif(0, 10000)", "s_c_p1[2] <- s_c_p1[1]", model_string_jags, fixed = TRUE) }
         if(pe_fixed > 1) {
-          model_string_jags <- gsub("alpha_p1[1, 2] <- alpha_p1[1, 1]", "alpha_p1[1, 2] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("alpha_p1[j, 2] <- alpha_p1[j, 1]", "alpha_p1[j, 2] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("alpha_p1[1, 2] <- alpha_p1[1, 1]", "alpha_p1[1, 2] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("alpha_p1[j, 2] <- alpha_p1[j, 1]", "alpha_p1[j, 2] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE) 
         }
-        if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p1[2] <- alpha_p1[1]", "alpha_p1[2] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE) }
+        if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p1[2] <- alpha_p1[1]", "alpha_p1[2] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE) }
         if(dist_e == "norm") {model_string_jags <- gsub("ls_e_p1[2] <- ls_e_p1[1]", "ls_e_p1[2] ~ dunif(-5, 10)", model_string_jags, fixed = TRUE) }
         if(dist_e == "beta") {model_string_jags <- gsub("s_e_p1[2] <- s_e_p1[1]", "s_e_p1[2] ~ dunif(0, sqrt(meane_p1[2] * (1 - meane_p1[2])))", model_string_jags, fixed = TRUE) }
         if(dist_e %in% c("gamma", "logis")) {model_string_jags <- gsub("s_e_p1[2] <- s_e_p1[1]", "s_e_p1[2] ~ dunif(0, 10000)", model_string_jags, fixed = TRUE) }
@@ -983,10 +983,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
         d1 <- ifelse(d1 == 4, 2, d1)
         if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p1[2] <- meanc_p1[2]", "mu_c_p1[2] <- meanc_p1[2] + Delta_c[1]", model_string_jags, fixed = TRUE) }
         if(pc_fixed > 1) {
-          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.0000001)", "beta_p1[1, 2] <- beta_p1[1, 1]", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.0000001)", "beta_p1[j, 2] <- beta_p1[j, 1]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[1, 2] ~ dnorm(0, 0.001)", "beta_p1[1, 2] <- beta_p1[1, 1]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[j, 2] ~ dnorm(0, 0.001)", "beta_p1[j, 2] <- beta_p1[j, 1]", model_string_jags, fixed = TRUE) 
         }
-        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.0000001)", "beta_p1[2] <- beta_p1[1]", model_string_jags, fixed = TRUE) }
+        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[2] ~ dnorm(0, 0.001)", "beta_p1[2] <- beta_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p1[2] ~ dunif(-5, 10)", "ls_c_p1[2] <- ls_c_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p1[2] ~ dunif(0, 100)", "ls_c_p1[2] <- ls_c_p1[1]", model_string_jags, fixed = TRUE) }
         if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p1[2] ~ dunif(0, 10000)", "s_c_p1[2] <- s_c_p1[1]", model_string_jags, fixed = TRUE) }
@@ -1021,10 +1021,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
         d1 <- ifelse(d1 == 4, 1, d1)
         if(type == "MNAR" | type == "MNAR_eff") {model_string_jags <- gsub("mu_e_p1[1] <- meane_p1[1]", "mu_e_p1[1] <- meane_p1[1] + Delta_e[1]", model_string_jags, fixed = TRUE) }
         if(pe_fixed > 1) {
-          model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.0000001)", "alpha_p1[1, 1] <- alpha_p1[1, 3]", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.0000001)", "alpha_p1[j, 1] <- alpha_p1[j, 3]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("alpha_p1[1, 1] ~ dnorm(0, 0.001)", "alpha_p1[1, 1] <- alpha_p1[1, 3]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("alpha_p1[j, 1] ~ dnorm(0, 0.001)", "alpha_p1[j, 1] <- alpha_p1[j, 3]", model_string_jags, fixed = TRUE) 
         }
-        if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.0000001)", "alpha_p1[1] <- alpha_p1[3]", model_string_jags, fixed = TRUE) }
+        if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p1[1] ~ dnorm(0, 0.001)", "alpha_p1[1] <- alpha_p1[3]", model_string_jags, fixed = TRUE) }
         if(dist_e == "norm") {model_string_jags <- gsub("ls_e_p1[1] ~ dunif(-5, 10)", "ls_e_p1[1] <- ls_e_p1[3]", model_string_jags, fixed = TRUE) }
         if(dist_e == "beta") {model_string_jags <- gsub("s_e_p1[1] ~ dunif(0, sqrt(meane_p1[1] * (1 - meane_p1[1])))", "s_e_p1[1] <- s_e_p1[3]", model_string_jags, fixed = TRUE) }
         if(dist_e %in% c("gamma", "logis")) {model_string_jags <- gsub("s_e_p1[1] ~ dunif(0, 10000)", "s_e_p1[1] <- s_e_p1[3]", model_string_jags, fixed = TRUE) }
@@ -1035,10 +1035,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
         if(dist_e == "nbinom") {model_string_jags <- gsub("tau_e_p1[1] ~ dunif(0, 100)", "tau_e_p1[1] <- tau_e_p1[3]", model_string_jags, fixed = TRUE) }
         if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p1[1] <- meanc_p1[1]", "mu_c_p1[1] <- meanc_p1[1] + Delta_c[1]", model_string_jags, fixed = TRUE) }
         if(pc_fixed > 1) {
-          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001)", "beta_p1[1, 1] <- beta_p1[1, 2]", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001)", "beta_p1[j, 1] <- beta_p1[j, 2]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001)", "beta_p1[1, 1] <- beta_p1[1, 2]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001)", "beta_p1[j, 1] <- beta_p1[j, 2]", model_string_jags, fixed = TRUE) 
         }
-        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.0000001)", "beta_p1[1] <- beta_p1[2]", model_string_jags, fixed = TRUE) }
+        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.001)", "beta_p1[1] <- beta_p1[2]", model_string_jags, fixed = TRUE) }
         if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p1[1] ~ dunif(-5, 10)", "ls_c_p1[1] <- ls_c_p1[2]", model_string_jags, fixed = TRUE) }
         if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p1[1] ~ dunif(0, 100)", "ls_c_p1[1] <- ls_c_p1[2]", model_string_jags, fixed = TRUE) }
         if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p1[1] ~ dunif(0, 10000)", "s_c_p1[1] <- s_c_p1[2]", model_string_jags, fixed = TRUE) }
@@ -1051,13 +1051,13 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
       if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p1[3] <- meanc_p1[3] + Delta_c[1]", "", model_string_jags, fixed = TRUE) }
       if(type == "MNAR" | type == "MNAR_eff") {model_string_jags <- gsub("mu_e_p1[3] <- meane_p1[3]", "", model_string_jags, fixed = TRUE) }
       if(pe_fixed > 1) {
-        model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p1[1, 3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
         model_string_jags <- gsub("alpha_p1[1, 2] <- alpha_p1[1, 3]", "alpha_p1[1, 2] <- alpha_p1[1, 1]", model_string_jags, fixed = TRUE) 
-        model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p1[j, 3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
         model_string_jags <- gsub("alpha_p1[j, 2] <- alpha_p1[j, 3]", "alpha_p1[j, 2] <- alpha_p1[j, 1]", model_string_jags, fixed = TRUE) 
       }
       if(pe_fixed == 1) {
-        model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p1[3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
         model_string_jags <- gsub("alpha_p1[2] <- alpha_p1[3]", "alpha_p1[2] <- alpha_p1[1]", model_string_jags, fixed = TRUE) 
       }
       if(pc_fixed > 1) {
@@ -1104,10 +1104,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
       if(ind_fixed == FALSE) {model_string_jags <- gsub("beta_f_p1[3] <- beta_f_p1[1]" , "", model_string_jags, fixed = TRUE) }
       if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p1[1] <- meanc_p1[1]", "mu_c_p1[1] <- meanc_p1[1] + Delta_c[1]", model_string_jags, fixed = TRUE) }
       if(pc_fixed > 1) {
-          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.0000001)", "beta_p1[1, 1] <- beta_p1[1, 2]", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.0000001)", "beta_p1[j, 1] <- beta_p1[j, 2]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[1, 1] ~ dnorm(0, 0.001)", "beta_p1[1, 1] <- beta_p1[1, 2]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p1[j, 1] ~ dnorm(0, 0.001)", "beta_p1[j, 1] <- beta_p1[j, 2]", model_string_jags, fixed = TRUE) 
       }
-      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.0000001)", "beta_p1[1] <- beta_p1[2]", model_string_jags, fixed = TRUE) }
+      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p1[1] ~ dnorm(0, 0.001)", "beta_p1[1] <- beta_p1[2]", model_string_jags, fixed = TRUE) }
       if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p1[1] ~ dunif(-5, 10)", "ls_c_p1[1] <- ls_c_p1[2]", model_string_jags, fixed = TRUE) }
       if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p1[1] ~ dunif(0, 100)", "ls_c_p1[1] <- ls_c_p1[2]", model_string_jags, fixed = TRUE) }
       if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p1[1] ~ dunif(0, 10000)", "s_c_p1[1] <- s_c_p1[2]", model_string_jags, fixed = TRUE) }
@@ -1141,10 +1141,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
       d2 <- ifelse(d2 == 4, 3, d2)
       if(type == "MNAR" | type == "MNAR_eff") {model_string_jags <- gsub("mu_e_p2[3] <- meane_p2[3]", "mu_e_p2[3] <- meane_p2[3] + Delta_e[2]", model_string_jags, fixed = TRUE) }
       if(pe_fixed > 1) {
-        model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.0000001)", "alpha_p2[1, 3] <- alpha_p2[1, 1]", model_string_jags, fixed = TRUE) 
-        model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.0000001)", "alpha_p2[j, 3] <- alpha_p2[j, 1]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.001)", "alpha_p2[1, 3] <- alpha_p2[1, 1]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.001)", "alpha_p2[j, 3] <- alpha_p2[j, 1]", model_string_jags, fixed = TRUE) 
         }
-      if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.0000001)", "alpha_p2[3] <- alpha_p2[1]", model_string_jags, fixed = TRUE) }
+      if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.001)", "alpha_p2[3] <- alpha_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_e == "norm") {model_string_jags <- gsub("ls_e_p2[3] ~ dunif(-5, 10)", "ls_e_p2[3] <- ls_e_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_e == "beta") {model_string_jags <- gsub("s_e_p2[3] ~ dunif(0, sqrt(meane_p2[3] * (1 - meane_p2[3])))", "s_e_p2[3] <- s_e_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_e %in% c("gamma", "logis")) {model_string_jags <- gsub("s_e_p2[3] ~ dunif(0, 10000)", "s_e_p2[3] <- s_e_p2[1]", model_string_jags, fixed = TRUE) }
@@ -1157,10 +1157,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
       d2 <- ifelse(d2 == 4, 2, d2)
       if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p2[2] <- meanc_p2[2]", "mu_c_p2[2] <- meanc_p2[2] + Delta_c[2]", model_string_jags, fixed = TRUE) }
       if(pc_fixed > 1) {
-        model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001)", "beta_p2[1, 2] <- beta_p2[1, 1]", model_string_jags, fixed = TRUE) 
-        model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001)", "beta_p2[j, 2] <- beta_p2[j, 1]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001)", "beta_p2[1, 2] <- beta_p2[1, 1]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001)", "beta_p2[j, 2] <- beta_p2[j, 1]", model_string_jags, fixed = TRUE) 
         }
-      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.0000001)", "beta_p2[2] <- beta_p2[1]", model_string_jags, fixed = TRUE) }
+      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.001)", "beta_p2[2] <- beta_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p2[2] ~ dunif(-5, 10)", "ls_c_p2[2] <- ls_c_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p2[2] ~ dunif(0, 100)", "ls_c_p2[2] <- ls_c_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p2[2] ~ dunif(0, 10000)", "s_c_p2[2] <- s_c_p2[1]", model_string_jags, fixed = TRUE) }
@@ -1172,10 +1172,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
     if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p2[3] <- meanc_p2[3] + Delta_c[2]", "", model_string_jags, fixed = TRUE) }
     if(type == "MNAR" | type == "MNAR_eff") {model_string_jags <- gsub("mu_e_p2[3] <- meane_p2[3]", "", model_string_jags, fixed = TRUE) }
     if(pe_fixed > 1) {
-      model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
-      model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
+      model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
+      model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
       }
-    if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) }
+    if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) }
     if(pc_fixed > 1) {
       model_string_jags <- gsub("beta_p2[1, 3] <- beta_p2[1, 1]", "", model_string_jags, fixed = TRUE) 
       model_string_jags <- gsub("beta_p2[j, 3] <- beta_p2[j, 1]", "", model_string_jags, fixed = TRUE) 
@@ -1196,18 +1196,18 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
       d2 <- ifelse(d2 == 3, 2, d2)
       if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p2[2] <- meanc_p2[2]", "mu_c_p2[2] <- meanc_p2[2] + Delta_c[2]", model_string_jags, fixed = TRUE) }
       if(pc_fixed > 1) {
-        model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001)", "beta_p2[1, 2] <- beta_p2[1, 1]", model_string_jags, fixed = TRUE) 
-        model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001)", "beta_p2[j, 2] <- beta_p2[j, 1]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001)", "beta_p2[1, 2] <- beta_p2[1, 1]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001)", "beta_p2[j, 2] <- beta_p2[j, 1]", model_string_jags, fixed = TRUE) 
         }
-      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.0000001)", "beta_p2[2] <- beta_p2[1]", model_string_jags, fixed = TRUE) }
+      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.001)", "beta_p2[2] <- beta_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p2[2] ~ dunif(-5, 10)", "ls_c_p2[2] <- ls_c_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p2[2] ~ dunif(0, 100)", "ls_c_p2[2] <- ls_c_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p2[2] ~ dunif(0, 10000)", "s_c_p2[2] <- s_c_p2[1]", model_string_jags, fixed = TRUE) }
       if(pe_fixed > 1) {
-        model_string_jags <- gsub("alpha_p2[1, 2] <- alpha_p2[1, 1]", "alpha_p2[1, 2] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE) 
-        model_string_jags <- gsub("alpha_p2[j, 2] <- alpha_p2[j, 1]", "alpha_p2[j, 2] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p2[1, 2] <- alpha_p2[1, 1]", "alpha_p2[1, 2] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p2[j, 2] <- alpha_p2[j, 1]", "alpha_p2[j, 2] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE) 
         }
-      if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p2[2] <- alpha_p2[1]", "alpha_p2[2] ~ dnorm(0, 0.0000001)", model_string_jags, fixed = TRUE) }
+      if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p2[2] <- alpha_p2[1]", "alpha_p2[2] ~ dnorm(0, 0.001)", model_string_jags, fixed = TRUE) }
       if(dist_e == "norm") {model_string_jags <- gsub("ls_e_p2[2] <- ls_e_p2[1]", "ls_e_p2[2] ~ dunif(-5, 10)", model_string_jags, fixed = TRUE) }
       if(dist_e == "beta") {model_string_jags <- gsub("s_e_p2[2] <- s_e_p2[1]", "s_e_p2[2] ~ dunif(0, sqrt(meane_p2[2] * (1 - meane_p2[2])))", model_string_jags, fixed = TRUE) }
       if(dist_e %in% c("gamma", "logis")) {model_string_jags <- gsub("s_e_p2[2] <- s_e_p2[1]", "s_e_p2[2] ~ dunif(0, 10000)", model_string_jags, fixed = TRUE) }
@@ -1220,10 +1220,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
       d2 <- ifelse(d2 == 4, 2, d2)
       if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p2[2] <- meanc_p2[2]", "mu_c_p2[2] <- meanc_p2[2] + Delta_c[2]", model_string_jags, fixed = TRUE) }
       if(pc_fixed > 1) {
-        model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.0000001)", "beta_p2[1, 2] <- beta_p2[1, 1]", model_string_jags, fixed = TRUE) 
-        model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.0000001)", "beta_p2[j, 2] <- beta_p2[j, 1]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("beta_p2[1, 2] ~ dnorm(0, 0.001)", "beta_p2[1, 2] <- beta_p2[1, 1]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("beta_p2[j, 2] ~ dnorm(0, 0.001)", "beta_p2[j, 2] <- beta_p2[j, 1]", model_string_jags, fixed = TRUE) 
         }
-      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.0000001)", "beta_p2[2] <- beta_p2[1]", model_string_jags, fixed = TRUE) }
+      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[2] ~ dnorm(0, 0.001)", "beta_p2[2] <- beta_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p2[2] ~ dunif(-5, 10)", "ls_c_p2[2] <- ls_c_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p2[2] ~ dunif(0, 100)", "ls_c_p2[2] <- ls_c_p2[1]", model_string_jags, fixed = TRUE) }
       if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p2[2] ~ dunif(0, 10000)", "s_c_p2[2] <- s_c_p2[1]", model_string_jags, fixed = TRUE) }
@@ -1258,10 +1258,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
         d2 <- ifelse(d2 == 4, 1, d2)
         if(type == "MNAR" | type == "MNAR_eff") {model_string_jags <- gsub("mu_e_p2[1] <- meane_p2[1]", "mu_e_p2[1] <- meane_p2[1] + Delta_e[2]", model_string_jags, fixed = TRUE) }
         if(pe_fixed > 1) {
-          model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.0000001)", "alpha_p2[1, 1] <- alpha_p2[1, 3]", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.0000001)", "alpha_p2[j, 1] <- alpha_p2[j, 3]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("alpha_p2[1, 1] ~ dnorm(0, 0.001)", "alpha_p2[1, 1] <- alpha_p2[1, 3]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("alpha_p2[j, 1] ~ dnorm(0, 0.001)", "alpha_p2[j, 1] <- alpha_p2[j, 3]", model_string_jags, fixed = TRUE) 
         }
-        if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.0000001)", "alpha_p2[1] <- alpha_p2[3]", model_string_jags, fixed = TRUE) }
+        if(pe_fixed == 1) {model_string_jags <- gsub("alpha_p2[1] ~ dnorm(0, 0.001)", "alpha_p2[1] <- alpha_p2[3]", model_string_jags, fixed = TRUE) }
         if(dist_e == "norm") {model_string_jags <- gsub("ls_e_p2[1] ~ dunif(-5, 10)", "ls_e_p2[1] <- ls_e_p2[3]", model_string_jags, fixed = TRUE) }
         if(dist_e == "beta") {model_string_jags <- gsub("s_e_p2[1] ~ dunif(0, sqrt(meane_p2[1] * (1 - meane_p2[1])))", "s_e_p2[1] <- s_e_p2[3]", model_string_jags, fixed = TRUE) }
         if(dist_e %in% c("gamma", "logis")) {model_string_jags <- gsub("s_e_p2[1] ~ dunif(0, 10000)", "s_e_p2[1] <- s_e_p2[3]", model_string_jags, fixed = TRUE) }
@@ -1272,10 +1272,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
         if(dist_e == "nbinom") {model_string_jags <- gsub("tau_e_p2[1] ~ dunif(0, 100)", "tau_e_p2[1] <- tau_e_p2[3]", model_string_jags, fixed = TRUE) }
         if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p2[1] <- meanc_p2[1]", "mu_c_p2[1] <- meanc_p2[1] + Delta_c[2]", model_string_jags, fixed = TRUE) }
         if(pc_fixed > 1) {
-          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001)", "beta_p2[1, 1] <- beta_p2[1, 2]", model_string_jags, fixed = TRUE) 
-          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001)", "beta_p2[j, 1] <- beta_p2[j, 2]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001)", "beta_p2[1, 1] <- beta_p2[1, 2]", model_string_jags, fixed = TRUE) 
+          model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001)", "beta_p2[j, 1] <- beta_p2[j, 2]", model_string_jags, fixed = TRUE) 
         }
-        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.0000001)", "beta_p2[1] <- beta_p2[2]", model_string_jags, fixed = TRUE) }
+        if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.001)", "beta_p2[1] <- beta_p2[2]", model_string_jags, fixed = TRUE) }
         if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p2[1] ~ dunif(-5, 10)", "ls_c_p2[1] <- ls_c_p2[2]", model_string_jags, fixed = TRUE) }
         if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p2[1] ~ dunif(0, 100)", "ls_c_p2[1] <- ls_c_p2[2]", model_string_jags, fixed = TRUE) }
         if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p2[1] ~ dunif(0, 10000)", "s_c_p2[1] <- s_c_p2[2]", model_string_jags, fixed = TRUE) }
@@ -1288,13 +1288,13 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
       if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p2[3] <- meanc_p2[3] + Delta_c[2]", "", model_string_jags, fixed = TRUE) }
       if(type == "MNAR" | type == "MNAR_eff") {model_string_jags <- gsub("mu_e_p2[3] <- meane_p2[3]", "", model_string_jags, fixed = TRUE) }
       if(pe_fixed > 1) {
-        model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p2[1, 3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
         model_string_jags <- gsub("alpha_p2[1, 2] <- alpha_p2[1, 3]", "alpha_p2[1, 2] <- alpha_p2[1, 1]", model_string_jags, fixed = TRUE) 
-        model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p2[j, 3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
         model_string_jags <- gsub("alpha_p2[j, 2] <- alpha_p2[j, 3]", "alpha_p2[j, 2] <- alpha_p2[j, 1]", model_string_jags, fixed = TRUE) 
       }
       if(pe_fixed == 1) {
-        model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("alpha_p2[3] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE) 
         model_string_jags <- gsub("alpha_p2[2] <- alpha_p2[3]", "alpha_p2[2] <- alpha_p2[1]", model_string_jags, fixed = TRUE) 
       }
       if(pc_fixed > 1) {
@@ -1341,10 +1341,10 @@ write_pattern <- function(type, dist_e, dist_c, pe_fixed, pc_fixed, ind_fixed, p
       if(ind_fixed == FALSE) {model_string_jags <- gsub("beta_f_p2[3] <- beta_f_p2[1]" , "", model_string_jags, fixed = TRUE) }
       if(type == "MNAR" | type == "MNAR_cost") {model_string_jags <- gsub("mu_c_p2[1] <- meanc_p2[1]", "mu_c_p2[1] <- meanc_p2[1] + Delta_c[2]", model_string_jags, fixed = TRUE) }
       if(pc_fixed > 1) {
-        model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.0000001)", "beta_p2[1, 1] <- beta_p2[1, 2]", model_string_jags, fixed = TRUE) 
-        model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.0000001)", "beta_p2[j, 1] <- beta_p2[j, 2]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("beta_p2[1, 1] ~ dnorm(0, 0.001)", "beta_p2[1, 1] <- beta_p2[1, 2]", model_string_jags, fixed = TRUE) 
+        model_string_jags <- gsub("beta_p2[j, 1] ~ dnorm(0, 0.001)", "beta_p2[j, 1] <- beta_p2[j, 2]", model_string_jags, fixed = TRUE) 
       }
-      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.0000001)", "beta_p2[1] <- beta_p2[2]", model_string_jags, fixed = TRUE) }
+      if(pc_fixed == 1) {model_string_jags <- gsub("beta_p2[1] ~ dnorm(0, 0.001)", "beta_p2[1] <- beta_p2[2]", model_string_jags, fixed = TRUE) }
       if(dist_c == "norm") {model_string_jags <- gsub("ls_c_p2[1] ~ dunif(-5, 10)", "ls_c_p2[1] <- ls_c_p2[2]", model_string_jags, fixed = TRUE) }
       if(dist_c == "lnorm") {model_string_jags <- gsub("ls_c_p2[1] ~ dunif(0, 100)", "ls_c_p2[1] <- ls_c_p2[2]", model_string_jags, fixed = TRUE) }
       if(dist_c == "gamma") {model_string_jags <- gsub("s_c_p2[1] ~ dunif(0, 10000)", "s_c_p2[1] <- s_c_p2[2]", model_string_jags, fixed = TRUE) }

--- a/R/write_selection.R
+++ b/R/write_selection.R
@@ -132,16 +132,16 @@ write_selection <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
   
   #priors for mean regression coefficients
   for (j in 2:pe_fixed) {#begin alpha priors effects
-  for(t in 1:2) {alpha[j, t] ~ dnorm(0, 0.0000001) }
+  for(t in 1:2) {alpha[j, t] ~ dnorm(0, 0.001) }
   }#end alpha priors effects
-  alpha[1, 1] ~ dnorm(0, 0.0000001)
-  alpha[1, 2] ~ dnorm(0, 0.0000001)
+  alpha[1, 1] ~ dnorm(0, 0.001)
+  alpha[1, 2] ~ dnorm(0, 0.001)
   
   for (j in 2:pc_fixed) {#begin beta priors costs
-  for(t in 1:2) {beta[j, t] ~ dnorm(0, 0.0000001) }
+  for(t in 1:2) {beta[j, t] ~ dnorm(0, 0.001) }
   }#end beta priors costs
-  beta[1, 1] ~ dnorm(0, 0.0000001)
-  beta[1, 2] ~ dnorm(0, 0.0000001)
+  beta[1, 1] ~ dnorm(0, 0.001)
+  beta[1, 2] ~ dnorm(0, 0.001)
   
   #priors for mean regression random coefficients
   for (j in 1:pe_random) {#begin a1 priors effects
@@ -164,7 +164,7 @@ write_selection <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
   ls_e[t] ~ dunif(-5, 10)
 
   #correlation
-  beta_f[t] ~ dnorm(0, 0.0000001)
+  beta_f[t] ~ dnorm(0, 0.001)
   
   # mean and sd mean regression random coefficients priors
   for(j in 1:pc_random) {mu_b_hat[j, t] ~ dnorm(0, 0.001)
@@ -564,7 +564,7 @@ write_selection <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
   if(ind_fixed == TRUE) {
   model_string_jags <- gsub(" + beta_f[1] * (eff1[i] - mu_e[1])", "", model_string_jags, fixed = TRUE)
   model_string_jags <- gsub(" + beta_f[2] * (eff2[i] - mu_e[2])", "", model_string_jags, fixed = TRUE)
-  model_string_jags <- gsub("beta_f[t] ~ dnorm(0, 0.0000001)", "", model_string_jags, fixed = TRUE)
+  model_string_jags <- gsub("beta_f[t] ~ dnorm(0, 0.001)", "", model_string_jags, fixed = TRUE)
   model_string_jags <- gsub("#correlation", "", model_string_jags, fixed = TRUE)
   } 
   if(dist_c == "norm") {
@@ -792,17 +792,17 @@ write_selection <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
    begin_prior_beta <- "#begin alpha priors effects"
    prior_beta <- "#"
    end_prior_beta <- "#end alpha priors effects"
-   prior_beta_e1 <- "alpha[1] ~ dnorm(0, 0.0000001)"
-   prior_beta_e2 <- "alpha[2] ~ dnorm(0, 0.0000001)"
+   prior_beta_e1 <- "alpha[1] ~ dnorm(0, 0.001)"
+   prior_beta_e2 <- "alpha[2] ~ dnorm(0, 0.001)"
    model_string_jags <- gsub("inprod(X1_e_fixed[i, ], alpha[, 1])", inprod_e1, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(X2_e_fixed[i, ], alpha[, 2])", inprod_e2, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(mean_cov_e1_fixed[], alpha[, 1])", inprod_mean_e1, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(mean_cov_e2_fixed[], alpha[, 2])", inprod_mean_e2, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("for (j in 2:pe_fixed) {#begin alpha priors effects", begin_prior_beta, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("for(t in 1:2) {alpha[j, t] ~ dnorm(0, 0.0000001) }", prior_beta, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("for(t in 1:2) {alpha[j, t] ~ dnorm(0, 0.001) }", prior_beta, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("}#end alpha priors effects", end_prior_beta, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("alpha[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_e1, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("alpha[1, 2] ~ dnorm(0, 0.0000001)", prior_beta_e2, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("alpha[1, 1] ~ dnorm(0, 0.001)", prior_beta_e1, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("alpha[1, 2] ~ dnorm(0, 0.001)", prior_beta_e2, model_string_jags, fixed = TRUE)
    }
    if(length(model_e_random) != 0 & pe_random == 1) {
        model_string_jags <- gsub("inprod(X1_e_random[i, ], a1[, clus1_e[i]])", "X1_e_random[i] * a1[clus1_e[i]]", model_string_jags, fixed = TRUE)
@@ -828,17 +828,17 @@ write_selection <- function(dist_e , dist_c, type, pe_fixed, pc_fixed, ze_fixed,
    begin_prior_beta <- "#begin beta priors costs"
    prior_beta <- "#"
    end_prior_beta <- "#end beta priors costs"
-   prior_beta_c1 <- "beta[1] ~ dnorm(0, 0.0000001)"
-   prior_beta_c2 <- "beta[2] ~ dnorm(0, 0.0000001)"
+   prior_beta_c1 <- "beta[1] ~ dnorm(0, 0.001)"
+   prior_beta_c2 <- "beta[2] ~ dnorm(0, 0.001)"
    model_string_jags <- gsub("inprod(X1_c_fixed[i, ], beta[, 1])", inprod_c1, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(X2_c_fixed[i, ], beta[, 2])", inprod_c2, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(mean_cov_c1_fixed[], beta[, 1])", inprod_mean_c1, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("inprod(mean_cov_c2_fixed[], beta[, 2])", inprod_mean_c2, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("for (j in 2:pc_fixed) {#begin beta priors costs", begin_prior_beta, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("for(t in 1:2) {beta[j, t] ~ dnorm(0, 0.0000001) }", prior_beta, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("for(t in 1:2) {beta[j, t] ~ dnorm(0, 0.001) }", prior_beta, model_string_jags, fixed = TRUE)
    model_string_jags <- gsub("}#end beta priors costs", end_prior_beta,model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("beta[1, 1] ~ dnorm(0, 0.0000001)", prior_beta_c1, model_string_jags, fixed = TRUE)
-   model_string_jags <- gsub("beta[1, 2] ~ dnorm(0, 0.0000001)", prior_beta_c2, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("beta[1, 1] ~ dnorm(0, 0.001)", prior_beta_c1, model_string_jags, fixed = TRUE)
+   model_string_jags <- gsub("beta[1, 2] ~ dnorm(0, 0.001)", prior_beta_c2, model_string_jags, fixed = TRUE)
    }
    if(length(model_c_random) != 0 & pc_random == 1) {
    model_string_jags <- gsub("inprod(X1_c_random[i, ], b1[, clus1_c[i]])", "X1_c_random[i] * b1[clus1_c[i]]", model_string_jags, fixed = TRUE)

--- a/vignettes/Model_customisation_in_missingHE.Rmd
+++ b/vignettes/Model_customisation_in_missingHE.Rmd
@@ -141,9 +141,9 @@ Prior values can be modified by first creating a list object which, for example,
 
 ```{r prior_hurdle1, eval=TRUE, echo=TRUE, comment=NA,warning=FALSE,error=FALSE,message=FALSE}
 my.prior <- list(
-  "alpha0.prior" = c(0 , 0.0000001),
-  "alpha.prior" = c(0, 0.0000001),
-  "beta0.prior" = c(0, 0.0000001),
+  "alpha0.prior" = c(0 , 0.001),
+  "alpha.prior" = c(0, 0.001),
+  "beta0.prior" = c(0, 0.001),
   "gamma0.prior.c"= c(0, 1),
   "gamma.prior.c" = c(0, 0.01),
   "mu.b0.prior" = c(0, 0.001),


### PR DESCRIPTION
In preparation for the release of JAGS 5.0.0 I am going through the reverse dependencies of the rjags package to ensure they work with the new version.

Changes to the way that initial values are calculated mean that JAGS does not work well with the extremely diffuse priors found in the missingHE package. In JAGS 4.x.y, initial values were set to deterministic "typical" values. For the normal distribution, the typical value is the prior mean. This allows the use of extremely diffuse normal priors like dnorm(0, 0.0000001) with a guaranteed starting value of 0.

In JAGS 5.0.0, initial values depend on the prior distribution. Ideally, initial values are drawn from the prior distribution but this is not compatible with diffuse priors. As a compromise, JAGS 5.0.0 sets the initial value to be the mean of N draws from the prior where by default N=10000. This works for, e.g. dnorm(0, 0.001) where it generates intial values with mean 0 and variance 0.1. However, this compromise still does not work for the very diffuse priors used in the missingHE package as it leads to the error message about parameter values being incompatible with the data. My suggestion is that you increase the prior precision of mean parameters. I don't think this will make a material difference to your parameter estimates but allows stable initial values to be generated.